### PR TITLE
Refactor grapheme cluster break property API.

### DIFF
--- a/src/unicode/emoji_segmenter.cpp
+++ b/src/unicode/emoji_segmenter.cpp
@@ -70,7 +70,7 @@ inline EmojiSegmentationCategory toCategory(char32_t codepoint) noexcept
         return EmojiSegmentationCategory::EmojiModifierBase;
     if (emoji_modifier(codepoint))
         return EmojiSegmentationCategory::EmojiModifier;
-    if (grapheme_cluster_break::regional_indicator(codepoint))
+    if (grapheme_cluster_break(codepoint) == Grapheme_Cluster_Break::Regional_Indicator)
         return EmojiSegmentationCategory::RegionalIndicator;
     if (isEmojiKeycapBase(codepoint))
         return EmojiSegmentationCategory::KeyCapBase;

--- a/src/unicode/grapheme_segmenter.h
+++ b/src/unicode/grapheme_segmenter.h
@@ -93,20 +93,24 @@ class grapheme_segmenter
         if (control(b))
             return true;
 
+        auto const A = grapheme_cluster_break(a);
+        auto const B = grapheme_cluster_break(b);
+
         // Do not break Hangul syllable sequences.
         // GB6:
-        if (grapheme_cluster_break::l(a)
-            && (grapheme_cluster_break::l(b) || grapheme_cluster_break::v(b) || grapheme_cluster_break::lv(b)
-                || grapheme_cluster_break::lvt(b)))
+        if (A == Grapheme_Cluster_Break::L
+            && (B == Grapheme_Cluster_Break::L || B == Grapheme_Cluster_Break::V
+                || B == Grapheme_Cluster_Break::LV || B == Grapheme_Cluster_Break::LVT))
             return false;
 
         // GB7:
-        if ((grapheme_cluster_break::lv(a) || grapheme_cluster_break::v(a))
-            && (grapheme_cluster_break::v(b) || grapheme_cluster_break::t(b)))
+        if ((A == Grapheme_Cluster_Break::LV || A == Grapheme_Cluster_Break::V)
+            && (B == Grapheme_Cluster_Break::V || B == Grapheme_Cluster_Break::T))
             return false;
 
         // GB8:
-        if ((grapheme_cluster_break::lv(a) || grapheme_cluster_break::t(a)) && grapheme_cluster_break::t(b))
+        if ((A == Grapheme_Cluster_Break::LV || A == Grapheme_Cluster_Break::T)
+            && B == Grapheme_Cluster_Break::T)
             return false;
 
         // GB9: Do not break before extending characters.
@@ -128,7 +132,8 @@ class grapheme_segmenter
         // GB12/GB13: Do not break within emoji flag sequences.
         // That is, do not break between regional indicator (RI) symbols
         // if there is an odd number of RI characters before the break point.
-        if (grapheme_cluster_break::regional_indicator(a) || grapheme_cluster_break::regional_indicator(b))
+        if (A == Grapheme_Cluster_Break::Regional_Indicator
+            || B == Grapheme_Cluster_Break::Regional_Indicator)
             return false;
 
         // GB999: Otherwise, break everywhere.


### PR DESCRIPTION
rewrite grapheme cluster break api to simply retrieve the property rather than providing X amount of test functions in order to improve grapheme cluster segmentation performance.