### PR TITLE
Fixes decoding invalid UTF-8 locking up.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## 0.2.1 (unreleased)
 
 - Fixes unicode-query's output for "character width".
+- Fixes decoding invalid UTF-8 locking up.
 - unicode-query is now linked statically on UNIX platforms.
 
 ## 0.2.0 (2022-11-13)

--- a/src/unicode/utf8.h
+++ b/src/unicode/utf8.h
@@ -137,7 +137,10 @@ inline ConvertResult from_utf8(utf8_decoder_state& _state, uint8_t _byte)
             _state.character = _byte & 0b0000'0111;
         }
         else
+        {
+            _state.currentLength = 1;
             return Invalid {};
+        }
     }
     else
     {

--- a/src/unicode/utf8_test.cpp
+++ b/src/unicode/utf8_test.cpp
@@ -138,6 +138,14 @@ TEST_CASE("utf8.from_utf8", "[utf8]")
     CHECK(b32 == U"😖:-)");
 }
 
+TEST_CASE("utf8.from_utf8.invalid", "[utf8]")
+{
+    // Ensure invalid bytes are consumed and ignored accordingly.
+    auto const a8 = string { "Hi\xb1Ho" };
+    auto const a32 = from_utf8(a8);
+    CHECK(a32 == U"HiHo");
+}
+
 TEST_CASE("utf8.iter", "[utf8]")
 {
     auto constexpr values = string_view {


### PR DESCRIPTION
Should fix the root cause in https://github.com/contour-terminal/contour/issues/980