### PR TITLE
Move `scan_result.next` to `scan_state.next`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - Fix UTF-8 decoding of incomplete UTF-8 multibyte sequences to properly report `Invalid`.
 - Change signature of `inline from_utf8(string_view const&)` slightly by dropping its cref.
+- Move `scan_result.next` to `scan_state.next`.
 
 ## 0.3.0 (2023-03-01)
 

--- a/src/libunicode/scan.h
+++ b/src/libunicode/scan.h
@@ -28,9 +28,6 @@ struct scan_result
     /// Codepoints with property East Asian Width Wide are treated as two columns.
     size_t count;
 
-    /// Pointer to one byte after the last scanned codepoint.
-    char const* next;
-
     /// Pointer to UTF-8 grapheme cluster start.
     char const* start;
 
@@ -48,6 +45,9 @@ struct scan_state
 {
     utf8_decoder_state utf8 {};
     char32_t lastCodepointHint {};
+
+    /// Pointer to one byte after the last scanned codepoint.
+    char const* next {};
 };
 
 /// Callback-interface that allows precisely understanding the structure of a UTF-8 sequence.


### PR DESCRIPTION
This is part of the attempt to rework the scan API working towards fixing https://github.com/contour-terminal/contour/issues/1062 and https://github.com/contour-terminal/contour/issues/980