### PR TITLE
Remove ubuntu 18.04 from github build actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,37 +25,6 @@ env:
   CTEST_OUTPUT_ON_FAILURE: 1
 
 jobs:
-  ubuntu_1804:
-    name: "Ubuntu Linux 18.04"
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: ccache-ubuntu_1804
-          max-size: 256M
-      - name: "install dependencies"
-        run: |
-          set -ex
-          sudo apt -q update
-          sudo apt install -y g++-8
-          sudo ./scripts/install-deps.sh
-      - name: "Get specific version CMake, v3.18.3"
-        uses: lukka/get-cmake@v3.18.3
-      - name: "create build directory"
-        run: mkdir build
-      - name: "cmake"
-        run: |
-          BUILD_DIR="build" \
-            CMAKE_BUILD_TYPE="Release" \
-            CXX="g++-8" \
-            ./scripts/ci-prepare.sh
-      - name: "build"
-        run: cmake --build build/ -- -j3
-      - name: "test"
-        run: ./build/src/libunicode/unicode_test
 
   ubuntu_matrix:
     strategy:


### PR DESCRIPTION
Remove Ubuntu 18.04 from build actions since ubuntu 18.04 is not longer supported as an OS for runners 