### PR TITLE
Update catch2 to v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ endif()
 include(EnableCcache)
 include(ClangTidy)
 include(PedanticCompiler)
-include(ThirdParties)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ${MASTER_PROJECT})
 option(LIBUNICODE_COVERAGE "libunicode: Builds with codecov [default: OFF]" OFF)
@@ -44,6 +43,8 @@ option(LIBUNICODE_EXAMPLES "libunicode: Enables building of example programs. [d
 option(LIBUNICODE_TESTING "libunicode: Enables building of unittests for libunicode [default: ${MASTER_PROJECT}" ${MASTER_PROJECT})
 option(LIBUNICODE_TOOLS "libunicode: Builds CLI tools [default: ${MASTER_PROJECT}]" ${MASTER_PROJECT})
 option(LIBUNICODE_BUILD_STATIC "libunicode: provide static library instead of dynamic [default: ${LIBUNICODE_BUILD_STATIC_DEFAULT}]" ${LIBUNICODE_BUILD_STATIC_DEFAULT})
+
+include(ThirdParties)
 
 if(LIBUNICODE_TESTING)
     enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,3 +101,5 @@ message(STATUS "Using ccache:                ${USING_CCACHE_STRING}")
 message(STATUS "Using UCD directory:         ${LIBUNICODE_UCD_DIR}")
 message(STATUS "Enable clang-tidy:           ${ENABLE_TIDY} (${CMAKE_CXX_CLANG_TIDY})")
 message(STATUS "------------------------------------------------------------------------------")
+
+ThirdPartiesSummary2()

--- a/cmake/ThirdParties.cmake
+++ b/cmake/ThirdParties.cmake
@@ -36,7 +36,7 @@ endmacro()
 # via find_package, usually system installed packages.
 
 if(LIBUNICODE_TESTING)
-    if (TARGET Catch2::Catch2)
+    if(TARGET Catch2::Catch2WithMain)
         set(THIRDPARTY_BUILTIN_Catch2 "embedded")
     else()
         find_package(Catch2 REQUIRED)

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -14,9 +14,9 @@ class ThirdParty
 $ThirdParties =
 @(
     [ThirdParty]@{
-        Folder="Catch2-2.13.7";
-        Archive="Catch2-2.13.7.zip";
-        URI="https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.7.zip"
+        Folder="Catch2-3.4.0";
+        Archive="Catch2-3.4.0.zip";
+        URI="https://github.com/catchorg/Catch2/archive/refs/tags/v3.4.0.zip"
     };
 )
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -65,9 +65,9 @@ fetch_and_unpack()
 fetch_and_unpack_Catch2()
 {
     fetch_and_unpack \
-        Catch2-2.13.7 \
-        Catch2-2.13.7.tar.gz \
-        https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.7.tar.gz
+        Catch2-3.4.0 \
+        Catch2-3.4.0.tar.gz \
+        https://github.com/catchorg/Catch2/archive/refs/tags/v3.4.0.tar.gz
 }
 
 fetch_and_unpack_fmtlib()

--- a/src/libunicode/CMakeLists.txt
+++ b/src/libunicode/CMakeLists.txt
@@ -197,7 +197,16 @@ if(LIBUNICODE_TESTING)
         width_test.cpp
         word_segmenter_test.cpp
     )
-    target_link_libraries(unicode_test PRIVATE unicode Catch2::Catch2WithMain fmt::fmt-header-only)
+
+    # supress conversion warnings for Catch2
+    # https://github.com/catchorg/Catch2/issues/2583
+    # https://github.com/SFML/SFML/blob/e45628e2ebc5843baa3739781276fa85a54d4653/test/CMakeLists.txt#L18-L22
+    set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "" EXPORT_COMPILE_COMMANDS OFF)
+    set_target_properties(Catch2WithMain PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
+    get_target_property(CATCH2_INCLUDE_DIRS Catch2 INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(Catch2 SYSTEM INTERFACE ${CATCH2_INCLUDE_DIRS})
+
+    target_link_libraries(unicode_test unicode Catch2::Catch2WithMain fmt::fmt-header-only)
     add_test(unicode_test unicode_test)
 endif()
 # }}}

--- a/src/libunicode/CMakeLists.txt
+++ b/src/libunicode/CMakeLists.txt
@@ -197,7 +197,7 @@ if(LIBUNICODE_TESTING)
         width_test.cpp
         word_segmenter_test.cpp
     )
-    target_link_libraries(unicode_test unicode Catch2::Catch2 fmt::fmt-header-only)
+    target_link_libraries(unicode_test PRIVATE unicode Catch2::Catch2WithMain fmt::fmt-header-only)
     add_test(unicode_test unicode_test)
 endif()
 # }}}

--- a/src/libunicode/capi_test.cpp
+++ b/src/libunicode/capi_test.cpp
@@ -15,7 +15,7 @@
 
 #include <fmt/format.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <array>
 #include <utility>

--- a/src/libunicode/convert_test.cpp
+++ b/src/libunicode/convert_test.cpp
@@ -17,7 +17,7 @@
 
 #include <fmt/format.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <iterator>
 

--- a/src/libunicode/emoji_segmenter_test.cpp
+++ b/src/libunicode/emoji_segmenter_test.cpp
@@ -18,7 +18,7 @@
 
 #include <fmt/format.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace unicode;
 using namespace std::string_literals;

--- a/src/libunicode/grapheme_segmenter_test.cpp
+++ b/src/libunicode/grapheme_segmenter_test.cpp
@@ -14,7 +14,7 @@
 #include <libunicode/convert.h>
 #include <libunicode/grapheme_segmenter.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace unicode;
 using namespace std::string_literals;

--- a/src/libunicode/run_segmenter_test.cpp
+++ b/src/libunicode/run_segmenter_test.cpp
@@ -18,7 +18,7 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <array>
 #include <sstream>

--- a/src/libunicode/scan_test.cpp
+++ b/src/libunicode/scan_test.cpp
@@ -17,7 +17,7 @@
 
 #include <fmt/format.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <string_view>
 

--- a/src/libunicode/script_segmenter_test.cpp
+++ b/src/libunicode/script_segmenter_test.cpp
@@ -13,7 +13,7 @@
  */
 #include <libunicode/script_segmenter.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <string>
 #include <string_view>

--- a/src/libunicode/test_main.cpp
+++ b/src/libunicode/test_main.cpp
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 #define CATCH_CONFIG_RUNNER
-#include <catch2/catch.hpp>
+#include <catch2/catch_session.hpp>
 
 int main(int argc, char const* argv[])
 {

--- a/src/libunicode/utf8_grapheme_segmenter_test.cpp
+++ b/src/libunicode/utf8_grapheme_segmenter_test.cpp
@@ -15,7 +15,7 @@
 
 #include <fmt/format.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <string_view>
 

--- a/src/libunicode/utf8_test.cpp
+++ b/src/libunicode/utf8_test.cpp
@@ -16,7 +16,7 @@
 
 #include <fmt/format.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <array>
 #include <cassert>

--- a/src/libunicode/width_test.cpp
+++ b/src/libunicode/width_test.cpp
@@ -13,7 +13,7 @@
  */
 #include <libunicode/width.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("random test", "[width]")
 {

--- a/src/libunicode/word_segmenter_test.cpp
+++ b/src/libunicode/word_segmenter_test.cpp
@@ -13,7 +13,7 @@
  */
 #include <libunicode/word_segmenter.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace unicode;
 using namespace std::string_literals;


### PR DESCRIPTION
close: #81 

I choose to use the [code snippet in SFML](https://github.com/SFML/SFML/blob/e45628e2ebc5843baa3739781276fa85a54d4653/test/CMakeLists.txt#L18-L22) to deal with the conversion warnings when compiling Catch2 v3 with option of `-DPEDANTIC_COMPILER_WERROR=ON` .