### PR TITLE
Fix ARM64 build on Windows

### DIFF
--- a/src/libunicode/CMakeLists.txt
+++ b/src/libunicode/CMakeLists.txt
@@ -34,7 +34,7 @@ if(LIBUNICODE_BUILD_STATIC)
 else()
     set(LIBUNICODE_LIB_MODE "SHARED")
 endif()
-message(STATUS "+++ LIBUNICODE_LIB_MODE: ${LIBUNICODE_LIB_MODE} +++")
+message(STATUS "libunicode library build mode: ${LIBUNICODE_LIB_MODE}")
 
 add_library(unicode_ucd ${LIBUNICODE_LIB_MODE}
     ucd.cpp

--- a/src/libunicode/scan.cpp
+++ b/src/libunicode/scan.cpp
@@ -42,7 +42,11 @@ namespace
     [[maybe_unused]] int countTrailingZeroBits(unsigned int value) noexcept
     {
 #if defined(_WIN32)
-        return _tzcnt_u32(value);
+        // return _tzcnt_u32(value);
+        // Don't do _tzcnt_u32, because that's only available on x86-64, but not on ARM64.
+        unsigned long r = 0;
+        _BitScanForward(&r, value);
+        return r;
 #else
         return __builtin_ctz(value);
 #endif


### PR DESCRIPTION
`_tzcnt_u32` is not available on ARM64/windows, but `_BitScanForward` is ;)