### PR TITLE
Fetch dependencies if OS is not supported

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,14 +40,14 @@ jobs:
             "Clang 11",
             "Clang 12"
           ]
-    name: "Ubuntu Linux 20.04 (${{ matrix.compiler }})"
-    runs-on: ubuntu-20.04
+    name: "Ubuntu Linux 22.04 (${{ matrix.compiler }})"
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: "ccache-ubuntu_2004-${{ matrix.compiler }}"
+          key: "ccache-ubuntu_2204-${{ matrix.compiler }}"
           max-size: 256M
       - name: "Update package database"
         run: sudo apt -q update
@@ -60,6 +60,35 @@ jobs:
       - name: "cmake"
         env:
           COMPILER: "${{ matrix.compiler }}"
+        run: |
+          BUILD_DIR="build" \
+            CMAKE_BUILD_TYPE="RelWithDebInfo" \
+            ./scripts/ci-prepare.sh
+      - name: "build"
+        run: cmake --build build/ -- -j3
+      - name: "test"
+        run: ./build/src/libunicode/unicode_test
+
+
+  unknown_os:
+    strategy:
+      fail-fast: false
+    name: "Unknown OS"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: "ccache-ubuntu_2004-${{ matrix.compiler }}"
+          max-size: 256M
+      - name: "Update package database"
+        run: sudo apt -q update
+      - name: "install dependencies"
+        run: OS_OVERRIDE=UNKNOWN ./scripts/install-deps.sh
+      - name: "create build directory"
+        run: mkdir build
+      - name: "cmake"
         run: |
           BUILD_DIR="build" \
             CMAKE_BUILD_TYPE="RelWithDebInfo" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,48 @@ jobs:
             "Clang 11",
             "Clang 12"
           ]
+    name: "Ubuntu Linux 20.04 (${{ matrix.compiler }})"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: "ccache-ubuntu_2004-${{ matrix.compiler }}"
+          max-size: 256M
+      - name: "Update package database"
+        run: sudo apt -q update
+      - name: "install dependencies"
+        env:
+          COMPILER: "${{ matrix.compiler }}"
+        run: ./scripts/install-deps.sh
+      - name: "create build directory"
+        run: mkdir build
+      - name: "cmake"
+        env:
+          COMPILER: "${{ matrix.compiler }}"
+        run: |
+          BUILD_DIR="build" \
+            CMAKE_BUILD_TYPE="RelWithDebInfo" \
+            ./scripts/ci-prepare.sh
+      - name: "build"
+        run: cmake --build build/ -- -j3
+      - name: "test"
+        run: ./build/src/libunicode/unicode_test
+
+
+  ubuntu_matrix_22:
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          [
+            "GCC 10",
+            "GCC 13",
+            "Clang 11",
+            "Clang 15"
+          ]
+          # gcc 13 only in github runners and not inside official repo
     name: "Ubuntu Linux 22.04 (${{ matrix.compiler }})"
     runs-on: ubuntu-22.04
     steps:

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -239,7 +239,11 @@ main()
             install_deps_FreeBSD
             ;;
         *)
-            echo "OS not supported."
+            fetch_and_unpack_Catch2
+            fetch_and_unpack_fmtlib
+            fetch_and_unpack_yaml_cpp
+            echo "OS $ID not supported."
+            echo "Dependencies were fetch manually and most likely libunicode will compile."
             ;;
     esac
 }

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -130,7 +130,7 @@ install_deps_ubuntu()
     fi
 
     case $RELEASE in
-        "18.04" | "19.04" | "20.04" | "21.04")
+        "18.04" | "19.04" | "20.04" | "21.04" | "22.04")
             fetch_and_unpack_fmtlib
             fetch_and_unpack_Catch2
             ;;


### PR DESCRIPTION
We need to fetch dependencies manually if OS is not supported so we can compile `libunicode`, 
I think that we need to update contour `libunicode` version after this PR as well