### PR TITLE
Fix build on FreeBSD Systems

### DIFF
--- a/src/libunicode/scan.cpp
+++ b/src/libunicode/scan.cpp
@@ -23,7 +23,7 @@
 #include <string_view>
 
 // clang-format off
-#if __has_include(<experimental/simd>) && defined(LIBUNICODE_USE_STD_SIMD) && !defined(__APPLE__)
+#if __has_include(<experimental/simd>) && defined(LIBUNICODE_USE_STD_SIMD) && !defined(__APPLE__) && !defined(__FreeBSD__)
     #define USE_STD_SIMD
     #include <experimental/simd>
     namespace stdx = std::experimental;


### PR DESCRIPTION
Fixes builds on FreeBSD where we error out with the namespace `std::experimental` not being found.

This is just a case of extending an already existing ifdef for Darwin by a case for FreeBSD.
