### PR TITLE
unicode-query: Show emoji presentation in Unicode properties query tool

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 0.5.0 (unreleased)
+
+- Show emoji presentation in Unicode properties query tool.
+
 ## 0.4.0 (2023-11-27)
 
 - Fix UTF-8 decoding of incomplete UTF-8 multibyte sequences to properly report `Invalid`.

--- a/src/tools/unicode-query.cpp
+++ b/src/tools/unicode-query.cpp
@@ -155,6 +155,7 @@ void showCodepointProperties(char32_t codepoint)
     cout << "East Asian Width            : " << properties.east_asian_width << '\n';
     cout << "Character width             : " << unsigned(properties.char_width) << '\n';
     cout << "Emoji Segmentation Category : " << properties.emoji_segmentation_category << '\n';
+    cout << "Emoji Presentation          : " << (properties.emoji_presentation() ? "emoji" : "text") << '\n';
     cout << "Grapheme Cluster Break      : " << properties.grapheme_cluster_break << '\n';
     cout << "\n";
     // clang-format on


### PR DESCRIPTION
I used it to figure out the default emoji presentation style for U+260D.
Seems like the sites I tested do not show this information, but I know we have it in our codepoint properties database.
I think it's worth adding it to `unicode-query` for future aids, as well.

Example output:

```sh
christianparpart@fedora ~/p/libunicode> unicode-query U+270D
Name                        : WRITING HAND
Unicode Version             : 1.1
Codepoint                   : U+270d
UTF-8                       : "\xe2\x9c\x8d"
Display                     : ✍
Plane                       : Basic_Multilingual_Plane
Block                       : Dingbats
Script                      : Common
General Category            : Other_Symbol
East Asian Width            : Neutral
Character width             : 1
Emoji Segmentation Category : EmojiModifierBase
Emoji Presentation          : text
Grapheme Cluster Break      : Other

```