### PR TITLE
word: implement UAX #29 Word Boundary segmentation (fixes #6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,9 +169,9 @@ jobs:
           PREPARE_ONLY_EMBEDS=OFF SYSDEP_ASSUME_YES=ON ./scripts/install-deps.sh
           dnf install -y unicode-ucd
       - name: configure
-        run: cmake --preset gcc-debug -DLIBUNICODE_UCD_DIR=/usr/share/unicode/ucd
+        run: cmake --preset gcc-release -DLIBUNICODE_UCD_DIR=/usr/share/unicode/ucd
       - name: build
-        run: cmake --build --preset gcc-debug -j$(nproc)
+        run: cmake --build --preset gcc-release -j$(nproc)
       - name: test
         run: |
-          ctest --preset gcc-debug
+          ctest --preset gcc-release

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -37,11 +37,11 @@ fetch_and_unpack()
     FULL_DISTFILE="$SYSDEPS_DIST_DIR/$DISTFILE"
 
     if ! test -f "$FULL_DISTFILE"; then
-        if which curl &>/dev/null; then
+        if command -v curl &>/dev/null; then
             curl -L -o "$FULL_DISTFILE" "$URL"
-        elif which wget &>/dev/null; then
+        elif command -v wget &>/dev/null; then
             wget -O "$FULL_DISTFILE" "$URL"
-        elif which fetch &>/dev/null; then
+        elif command -v fetch &>/dev/null; then
             # FreeBSD
             fetch -o "$FULL_DISTFILE" "$URL"
         else

--- a/src/libunicode/CMakeLists.txt
+++ b/src/libunicode/CMakeLists.txt
@@ -160,6 +160,7 @@ add_library(unicode ${LIBUNICODE_LIB_MODE}
     emoji_segmenter.cpp
     grapheme_segmenter.cpp
     normalization.cpp
+    word_segmenter.cpp
     scan.cpp
     script_segmenter.cpp
     utf8.cpp
@@ -323,6 +324,7 @@ if(LIBUNICODE_TESTING)
     endif()
 
     target_link_libraries(unicode_test unicode Catch2::Catch2WithMain)
+    target_compile_definitions(unicode_test PRIVATE LIBUNICODE_UCD_DIR="${LIBUNICODE_UCD_DIR}")
     add_test(unicode_test unicode_test)
 endif()
 # }}}

--- a/src/libunicode/case_mapping.cpp
+++ b/src/libunicode/case_mapping.cpp
@@ -223,42 +223,42 @@ std::u32string to_titlecase(std::u32string_view text)
     std::u32string result;
     result.reserve(text.size());
 
-    bool at_word_start = true;
-
-    for (char32_t cp: text)
+    auto seg = word_segmenter(text);
+    while (true)
     {
-        // Simple word boundary detection: after space/punctuation
-        bool const is_letter = is_cased(cp);
+        auto const word = *seg;
+        if (word.empty() && !seg.codepointsAvailable())
+            break;
 
-        if (at_word_start && is_letter)
+        auto firstCased = true;
+        for (auto const cp: word)
         {
-            // Titlecase the first letter of a word
-            auto const mapping = full_titlecase(cp);
-            if (mapping.is_identity())
-                result.push_back(cp);
-            else
-                result.append(mapping.view());
-            at_word_start = false;
-        }
-        else if (is_letter)
-        {
-            // Lowercase the rest of the word
-            auto const mapping = full_lowercase(cp);
-            if (mapping.is_identity())
-                result.push_back(cp);
-            else
-                result.append(mapping.view());
-        }
-        else
-        {
-            result.push_back(cp);
-            // Check if this is a word boundary
-            if (cp == ' ' || cp == '\t' || cp == '\n' || cp == '\r' || general_category::is_dash_punctuation(cp)
-                || general_category::is_open_punctuation(cp) || general_category::is_close_punctuation(cp))
+            if (firstCased && is_cased(cp))
             {
-                at_word_start = true;
+                auto const mapping = full_titlecase(cp);
+                if (mapping.is_identity())
+                    result.push_back(cp);
+                else
+                    result.append(mapping.view());
+                firstCased = false;
+            }
+            else if (!firstCased && is_cased(cp))
+            {
+                auto const mapping = full_lowercase(cp);
+                if (mapping.is_identity())
+                    result.push_back(cp);
+                else
+                    result.append(mapping.view());
+            }
+            else
+            {
+                result.push_back(cp);
             }
         }
+
+        if (!seg.codepointsAvailable())
+            break;
+        ++seg;
     }
 
     return result;
@@ -357,9 +357,12 @@ bool is_case_ignorable(char32_t codepoint) noexcept
     // Case_Ignorable includes:
     // - General_Category = Mn, Me, Cf, Lm, Sk
     // - Word_Break = MidLetter, MidNumLet, Single_Quote
-    auto const gc = general_category::get(codepoint);
+    auto const props = codepoint_properties::get(codepoint);
+    auto const gc = props.general_category;
+    auto const wb = props.word_break;
     return gc == General_Category::Nonspacing_Mark || gc == General_Category::Enclosing_Mark || gc == General_Category::Format
-           || gc == General_Category::Modifier_Letter || gc == General_Category::Modifier_Symbol;
+           || gc == General_Category::Modifier_Letter || gc == General_Category::Modifier_Symbol || wb == Word_Break::MidLetter
+           || wb == Word_Break::MidNumLet || wb == Word_Break::Single_Quote;
 }
 
 bool changes_when_uppercased(char32_t codepoint) noexcept

--- a/src/libunicode/codepoint_properties.h
+++ b/src/libunicode/codepoint_properties.h
@@ -34,6 +34,7 @@ struct LIBUNICODE_PACKED codepoint_properties
     EmojiSegmentationCategory emoji_segmentation_category = EmojiSegmentationCategory::Invalid;
     Age age = Age::Unassigned;
     Indic_Conjunct_Break indic_conjunct_break = Indic_Conjunct_Break::None;
+    Word_Break word_break = Word_Break::Other;
 
     static uint8_t constexpr FlagEmoji = 0x01;                // NOLINT(readability-identifier-naming)
     static uint8_t constexpr FlagEmojiPresentation = 0x02;    // NOLINT(readability-identifier-naming)

--- a/src/libunicode/tablegen/multistage_generator.cpp
+++ b/src/libunicode/tablegen/multistage_generator.cpp
@@ -80,10 +80,11 @@ namespace
         int8_t emoji_segmentation_category = ESC_Invalid;
         uint8_t age = 0;
         uint8_t indic_conjunct_break = 3; // Default: Indic_Conjunct_Break::None
+        uint8_t word_break = 18;          // Default: Word_Break::Other
     };
 #pragma pack(pop)
 
-    static_assert(sizeof(CodepointRecord) == 9, "CodepointRecord must be exactly 9 bytes");
+    static_assert(sizeof(CodepointRecord) == 10, "CodepointRecord must be exactly 10 bytes");
 
     inline bool operator==(CodepointRecord const& a, CodepointRecord const& b) noexcept
     {
@@ -238,17 +239,18 @@ namespace
     }
 
     /// Reverse lookup: index -> name for a PVA-based enum.
+    /// Prefers the longest matching name to avoid returning abbreviations.
     std::string reverseLookup(std::map<std::string, uint8_t> const& index,
                               uint8_t value,
                               std::string const& defaultName = "Unknown")
     {
+        std::string bestName;
         for (auto const& [name, idx]: index)
         {
-            // Skip abbreviation keys (single letters or 2-letter) — only match full names
-            if (idx == value && name.size() > 2)
-                return name;
+            if (idx == value && name.size() > bestName.size())
+                bestName = name;
         }
-        return defaultName;
+        return bestName.empty() ? defaultName : bestName;
     }
 
     std::string_view escName(int8_t idx)
@@ -341,6 +343,7 @@ void generateMultistageFiles(UcdParser const& parser, std::string const& outputD
     auto const ageIndex = buildAgeIndex(findPva("Age"));
     auto const gcbIndex = buildPvaBasedIndex(findPva("Grapheme_Cluster_Break"), "Undefined");
     auto const incbIndex = buildPvaBasedIndex(findPva("Indic_Conjunct_Break"));
+    auto const wbIndex = buildPvaBasedIndex(findPva("Word_Break"));
 
     // Name vectors for output
     auto const scriptNames = buildScriptNames(parser.scripts());
@@ -388,6 +391,7 @@ void generateMultistageFiles(UcdParser const& parser, std::string const& outputD
         // General_Category::Unassigned is a member name in the GC enum
         auto gcUnassigned = gcIndex.count("Unassigned") ? gcIndex.at("Unassigned") : uint8_t(0);
         auto incbNone = incbIndex.count("None") ? incbIndex.at("None") : uint8_t(3);
+        auto wbOther = wbIndex.count("Other") ? wbIndex.at("Other") : uint8_t(18);
         for (auto& rec: records)
         {
             rec.script = scriptUnknown;
@@ -395,6 +399,7 @@ void generateMultistageFiles(UcdParser const& parser, std::string const& outputD
             rec.east_asian_width = eawNarrow;
             rec.general_category = gcUnassigned;
             rec.indic_conjunct_break = incbNone;
+            rec.word_break = wbOther;
         }
     }
 
@@ -479,6 +484,19 @@ void generateMultistageFiles(UcdParser const& parser, std::string const& outputD
         for (auto const& r: ranges)
             for (auto cp = r.first; cp <= r.last; ++cp)
                 records[static_cast<size_t>(cp)].indic_conjunct_break = it->second;
+    }
+
+    // Word Break
+    for (auto const& [propName, ranges]: parser.wordBreakProps())
+    {
+        for (auto const& r: ranges)
+        {
+            auto it = wbIndex.find(r.property);
+            if (it == wbIndex.end())
+                continue;
+            for (auto cp = r.first; cp <= r.last; ++cp)
+                records[static_cast<size_t>(cp)].word_break = it->second;
+        }
     }
 
     // East Asian Width
@@ -615,7 +633,8 @@ void generateMultistageFiles(UcdParser const& parser, std::string const& outputD
              << ", "
              << "EmojiSegmentationCategory::" << escName(rec.emoji_segmentation_category) << ", "
              << "Age::" << (rec.age < ageNames.size() ? ageNames[rec.age] : "Unassigned") << ", "
-             << "Indic_Conjunct_Break::" << reverseLookup(incbIndex, rec.indic_conjunct_break, "None") << "},\n";
+             << "Indic_Conjunct_Break::" << reverseLookup(incbIndex, rec.indic_conjunct_break, "None") << ", "
+             << "Word_Break::" << reverseLookup(wbIndex, rec.word_break, "Other") << "},\n";
     }
     impl << "}};\n\n";
 

--- a/src/libunicode/tablegen/ucd_parser.cpp
+++ b/src/libunicode/tablegen/ucd_parser.cpp
@@ -193,6 +193,7 @@ void UcdParser::parseAll()
 
     // Phase 2: UCD API files
     loadGraphemeBreakProps();
+    loadWordBreakProps();
     loadEastAsianWidths();
     loadHangulSyllableType();
     loadEmojiProps();
@@ -435,6 +436,13 @@ void UcdParser::loadBlocks()
 void UcdParser::loadGraphemeBreakProps()
 {
     _graphemeBreakProps = loadGroupedProperties(_ucdDir + "/auxiliary/GraphemeBreakProperty.txt", "Property");
+}
+
+// ---- Word Break Properties ----
+
+void UcdParser::loadWordBreakProps()
+{
+    _wordBreakProps = loadGroupedProperties(_ucdDir + "/auxiliary/WordBreakProperty.txt", "Property");
 }
 
 // ---- East Asian Widths ----

--- a/src/libunicode/tablegen/ucd_parser.h
+++ b/src/libunicode/tablegen/ucd_parser.h
@@ -119,6 +119,9 @@ class UcdParser
     /// Grapheme cluster break properties grouped by property name.
     [[nodiscard]] auto const& graphemeBreakProps() const noexcept { return _graphemeBreakProps; }
 
+    /// Word break properties grouped by property name.
+    [[nodiscard]] auto const& wordBreakProps() const noexcept { return _wordBreakProps; }
+
     /// East Asian Width ranges, sorted by start codepoint.
     [[nodiscard]] auto const& eastAsianWidths() const noexcept { return _eastAsianWidths; }
 
@@ -176,6 +179,7 @@ class UcdParser
     void loadScriptExtensions();
     void loadBlocks();
     void loadGraphemeBreakProps();
+    void loadWordBreakProps();
     void loadEastAsianWidths();
     void loadHangulSyllableType();
     void loadEmojiProps();
@@ -229,6 +233,9 @@ class UcdParser
 
     // Grapheme break props
     std::map<std::string, std::vector<PropertyRange>> _graphemeBreakProps;
+
+    // Word break props
+    std::map<std::string, std::vector<PropertyRange>> _wordBreakProps;
 
     // East Asian Width
     std::vector<PropertyRange> _eastAsianWidths;

--- a/src/libunicode/word_segmenter.cpp
+++ b/src/libunicode/word_segmenter.cpp
@@ -1,0 +1,296 @@
+/**
+ * This file is part of the "libunicode" project
+ *   Copyright (c) 2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <libunicode/word_segmenter.h>
+
+#include <optional>
+
+namespace unicode
+{
+
+namespace
+{
+    /// AHLetter = ALetter | Hebrew_Letter
+    bool is_AHLetter(Word_Break wb) noexcept
+    {
+        return wb == Word_Break::ALetter || wb == Word_Break::Hebrew_Letter;
+    }
+
+    /// MidNumLetQ = MidNumLet | Single_Quote
+    bool is_MidNumLetQ(Word_Break wb) noexcept
+    {
+        return wb == Word_Break::MidNumLet || wb == Word_Break::Single_Quote;
+    }
+
+    /// MidLetter or MidNumLetQ
+    bool is_MidLetterLike(Word_Break wb) noexcept
+    {
+        return wb == Word_Break::MidLetter || is_MidNumLetQ(wb);
+    }
+
+    /// MidNum or MidNumLetQ
+    bool is_MidNumLike(Word_Break wb) noexcept
+    {
+        return wb == Word_Break::MidNum || is_MidNumLetQ(wb);
+    }
+
+    /// Whether a Word_Break value is "transparent" per WB4: Extend, Format, or ZWJ.
+    bool is_transparent(Word_Break wb) noexcept
+    {
+        return wb == Word_Break::Extend || wb == Word_Break::Format || wb == Word_Break::ZWJ;
+    }
+
+    /// Whether a Word_Break value is a newline-class value (Newline, CR, LF).
+    bool is_newline_class(Word_Break wb) noexcept
+    {
+        return wb == Word_Break::Newline || wb == Word_Break::CR || wb == Word_Break::LF;
+    }
+
+    /// Peek past transparent (Extend/Format/ZWJ) codepoints and return the
+    /// Word_Break property of the next non-transparent codepoint, if any.
+    std::optional<Word_Break> peek_next_non_transparent(char32_t const* rest, size_t count) noexcept
+    {
+        for (size_t i = 0; i < count; ++i)
+        {
+            auto const wb = codepoint_properties::get(rest[i]).word_break;
+            if (!is_transparent(wb))
+                return wb;
+        }
+        return std::nullopt;
+    }
+
+    /// Update state when a new non-transparent codepoint is encountered.
+    void update_effective(Word_Break wb, word_segmenter_state& state) noexcept
+    {
+        state.prev_prev_wb = state.prev_wb;
+        state.prev_wb = wb;
+        state.raw_prev_wb = wb;
+        state.ri_counter = (wb == Word_Break::Regional_Indicator) ? static_cast<uint8_t>(state.ri_counter + 1) : 0;
+        state.saw_transparent = false;
+    }
+
+} // namespace
+
+void word_process_init(char32_t firstCodepoint, word_segmenter_state& state) noexcept
+{
+    auto const props = codepoint_properties::get(firstCodepoint);
+    auto const wb = props.word_break;
+
+    state.raw_prev_wb = wb;
+    state.prev_prev_wb = Word_Break::Other;
+
+    if (is_transparent(wb))
+    {
+        // Transparent characters as first codepoint: keep prev_wb as Other,
+        // but raw_prev_wb tracks the actual character.
+        state.prev_wb = Word_Break::Other;
+        state.ri_counter = 0;
+    }
+    else
+    {
+        state.prev_wb = wb;
+        state.ri_counter = (wb == Word_Break::Regional_Indicator) ? 1 : 0;
+    }
+}
+
+bool word_process_breakable(char32_t nextCodepoint, char32_t const* rest, size_t restCount, word_segmenter_state& state) noexcept
+{
+    auto const props = codepoint_properties::get(nextCodepoint);
+    auto const B = props.word_break;
+
+    // --- Rules evaluated BEFORE WB4 (on raw previous) ---
+
+    // WB3: CR x LF
+    if (state.raw_prev_wb == Word_Break::CR && B == Word_Break::LF)
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB3a: (Newline | CR | LF) ÷
+    if (is_newline_class(state.raw_prev_wb))
+    {
+        if (is_transparent(B))
+        {
+            state.raw_prev_wb = B;
+            state.prev_wb = Word_Break::Other;
+            state.prev_prev_wb = Word_Break::Other;
+            state.ri_counter = 0;
+        }
+        else
+        {
+            update_effective(B, state);
+        }
+        return true;
+    }
+
+    // WB3b: ÷ (Newline | CR | LF)
+    if (is_newline_class(B))
+    {
+        update_effective(B, state);
+        return true;
+    }
+
+    // WB3c: ZWJ x \p{Extended_Pictographic}
+    if (state.raw_prev_wb == Word_Break::ZWJ && props.is_extended_pictographic())
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB4: Ignore Extend, Format, ZWJ for subsequent rules
+    // (except after Newline/CR/LF which was already handled above)
+    if (is_transparent(B))
+    {
+        state.raw_prev_wb = B;
+        state.saw_transparent = true;
+        // Do NOT update prev_wb/prev_prev_wb — B is transparent
+        return false;
+    }
+
+    // --- From here, B is non-transparent. Use effective state for rules. ---
+    auto const A = state.prev_wb;
+
+    // WB3d: WSegSpace x WSegSpace
+    // Only applies when directly adjacent (no intervening Extend/Format/ZWJ).
+    if (A == Word_Break::WSegSpace && B == Word_Break::WSegSpace && !state.saw_transparent)
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB5: AHLetter x AHLetter
+    if (is_AHLetter(A) && is_AHLetter(B))
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB6: AHLetter x (MidLetter | MidNumLetQ) AHLetter
+    if (is_AHLetter(A) && is_MidLetterLike(B))
+    {
+        auto const next = peek_next_non_transparent(rest, restCount);
+        if (next && is_AHLetter(*next))
+        {
+            update_effective(B, state);
+            return false;
+        }
+    }
+
+    // WB7: AHLetter (MidLetter | MidNumLetQ) x AHLetter
+    if (is_MidLetterLike(A) && is_AHLetter(B) && is_AHLetter(state.prev_prev_wb))
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB7a: Hebrew_Letter x Single_Quote
+    if (A == Word_Break::Hebrew_Letter && B == Word_Break::Single_Quote)
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB7b: Hebrew_Letter x Double_Quote Hebrew_Letter
+    if (A == Word_Break::Hebrew_Letter && B == Word_Break::Double_Quote)
+    {
+        auto const next = peek_next_non_transparent(rest, restCount);
+        if (next && *next == Word_Break::Hebrew_Letter)
+        {
+            update_effective(B, state);
+            return false;
+        }
+    }
+
+    // WB7c: Hebrew_Letter Double_Quote x Hebrew_Letter
+    if (A == Word_Break::Double_Quote && B == Word_Break::Hebrew_Letter && state.prev_prev_wb == Word_Break::Hebrew_Letter)
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB8: Numeric x Numeric
+    if (A == Word_Break::Numeric && B == Word_Break::Numeric)
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB9: AHLetter x Numeric
+    if (is_AHLetter(A) && B == Word_Break::Numeric)
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB10: Numeric x AHLetter
+    if (A == Word_Break::Numeric && is_AHLetter(B))
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB11: Numeric (MidNum | MidNumLetQ) x Numeric
+    if (is_MidNumLike(A) && B == Word_Break::Numeric && state.prev_prev_wb == Word_Break::Numeric)
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB12: Numeric x (MidNum | MidNumLetQ) Numeric
+    if (A == Word_Break::Numeric && is_MidNumLike(B))
+    {
+        auto const next = peek_next_non_transparent(rest, restCount);
+        if (next && *next == Word_Break::Numeric)
+        {
+            update_effective(B, state);
+            return false;
+        }
+    }
+
+    // WB13: Katakana x Katakana
+    if (A == Word_Break::Katakana && B == Word_Break::Katakana)
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB13a: (AHLetter | Numeric | Katakana | ExtendNumLet) x ExtendNumLet
+    if (B == Word_Break::ExtendNumLet
+        && (is_AHLetter(A) || A == Word_Break::Numeric || A == Word_Break::Katakana || A == Word_Break::ExtendNumLet))
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB13b: ExtendNumLet x (AHLetter | Numeric | Katakana)
+    if (A == Word_Break::ExtendNumLet && (is_AHLetter(B) || B == Word_Break::Numeric || B == Word_Break::Katakana))
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB15/WB16: Do not break within emoji flag sequences.
+    // sot (RI RI)* RI x RI  /  [^RI] (RI RI)* RI x RI
+    if (A == Word_Break::Regional_Indicator && B == Word_Break::Regional_Indicator && (state.ri_counter % 2) == 1)
+    {
+        update_effective(B, state);
+        return false;
+    }
+
+    // WB999: Otherwise, break everywhere.
+    update_effective(B, state);
+    return true;
+}
+
+} // namespace unicode

--- a/src/libunicode/word_segmenter.h
+++ b/src/libunicode/word_segmenter.h
@@ -13,91 +13,107 @@
  */
 #pragma once
 
+#include <libunicode/codepoint_properties.h>
+
 #include <string_view>
 
 namespace unicode
 {
 
+/// State for incremental word boundary detection per UAX #29.
+struct word_segmenter_state
+{
+    /// Raw WB property of the immediately previous codepoint (before WB4 filtering).
+    /// Used for WB3 (CR x LF), WB3a, WB3b, WB3c.
+    Word_Break raw_prev_wb = Word_Break::Other;
+
+    /// Effective WB property of the most recent non-transparent codepoint (after WB4 filtering).
+    /// Used for rules WB5-WB16.
+    Word_Break prev_wb = Word_Break::Other;
+
+    /// Effective WB property of the codepoint before prev_wb.
+    /// Needed for WB7, WB7c, WB11.
+    Word_Break prev_prev_wb = Word_Break::Other;
+
+    /// Regional Indicator counter (modulo 2) for WB15/WB16.
+    uint8_t ri_counter = 0;
+
+    /// Whether any transparent (Extend/Format/ZWJ) characters have been seen
+    /// since the last non-transparent codepoint. Needed for WB3d which only
+    /// matches directly adjacent WSegSpace characters.
+    bool saw_transparent = false;
+};
+
+/// Initializes word segmentation state for the first codepoint.
+void word_process_init(char32_t firstCodepoint, word_segmenter_state& state) noexcept;
+
+/// Tests if there is a word boundary before @p nextCodepoint.
+///
+/// @param nextCodepoint The codepoint to test.
+/// @param rest Pointer to codepoints after @p nextCodepoint (for lookahead).
+/// @param restCount Number of codepoints available after @p nextCodepoint.
+/// @param state Mutable segmentation state, updated on each call.
+///
+/// @retval true  There is a word boundary before @p nextCodepoint.
+/// @retval false No word boundary; @p nextCodepoint belongs to the same word segment.
+bool word_process_breakable(char32_t nextCodepoint, char32_t const* rest, size_t restCount, word_segmenter_state& state) noexcept;
+
+/// Implements https://www.unicode.org/reports/tr29/#Word_Boundary_Rules
 class word_segmenter
 {
   public:
-    using char_type = char32_t;
-    using iterator = char_type const*;
-    using view_type = std::basic_string_view<char_type>;
-
-    constexpr word_segmenter(std::basic_string_view<char_type> const& str): word_segmenter(str.data(), str.data() + str.size()) {}
-
-    constexpr word_segmenter(): word_segmenter({}, {}) {}
-
-    constexpr bool empty() const noexcept { return size() == 0; }
-    constexpr std::size_t size() const noexcept { return static_cast<size_t>(_right - _left); }
-    constexpr view_type operator*() const noexcept { return view_type(_left, size()); }
-
-    constexpr word_segmenter& operator++() noexcept
-    {
-        _left = _right;
-        while (_right != _end)
-        {
-            switch (_state)
-            {
-                case State::NoWord:
-                    if (!isDelimiter(*_right))
-                    {
-                        _state = State::Word;
-                        return *this;
-                    }
-                    break;
-                case State::Word:
-                    if (isDelimiter(*_right))
-                    {
-                        _state = State::NoWord;
-                        return *this;
-                    }
-                    break;
-            }
-            ++_right;
-        }
-        return *this;
-    }
-
-    constexpr bool operator==(word_segmenter const& rhs) const noexcept { return _left == rhs._left && _right == rhs._right; }
-
-    constexpr bool operator!=(word_segmenter const& rhs) const noexcept { return !(*this == rhs); }
-
-  private:
-    constexpr word_segmenter(iterator begin, iterator end):
-        _left { begin },
-        _right { begin },
-        _state { begin != end ? (isDelimiter(*_right) ? State::NoWord : State::Word) : State::NoWord },
-        _end { end }
+    word_segmenter(char32_t const* begin, char32_t const* end) noexcept:
+        left_ { begin }, right_ { begin }, end_ { end }, state_ {}
     {
         ++*this;
     }
 
-    constexpr bool isDelimiter(char_type character) const noexcept
+    word_segmenter(std::u32string_view sv) noexcept: word_segmenter(sv.data(), sv.data() + sv.size()) {}
+
+    word_segmenter() noexcept: word_segmenter(static_cast<char32_t const*>(nullptr), static_cast<char32_t const*>(nullptr)) {}
+
+    word_segmenter& operator++() noexcept
     {
-        switch (character)
+        left_ = right_;
+        if (right_ == end_)
+            return *this;
+
+        word_process_init(*right_++, state_);
+
+        while (right_ != end_)
         {
-            case ' ':
-            case '\r':
-            case '\n':
-            case '\t': return true;
-            default: return false;
+            auto const* rest = right_ + 1;
+            auto const restCount = static_cast<size_t>(end_ - rest);
+            if (word_process_breakable(*right_, rest, restCount, state_))
+                break;
+            ++right_;
         }
+
+        return *this;
     }
 
-    // private fields
-    //
-    enum class State
+    constexpr std::u32string_view operator*() const noexcept
     {
-        Word,
-        NoWord
-    };
+        return std::u32string_view(left_, static_cast<size_t>(right_ - left_));
+    }
 
-    iterator _left;
-    iterator _right;
-    State _state;
-    iterator _end;
+    constexpr bool codepointsAvailable() const noexcept { return right_ != end_; }
+
+    explicit constexpr operator bool() const noexcept { return codepointsAvailable(); }
+
+    constexpr bool empty() const noexcept { return size() == 0; }
+    constexpr size_t size() const noexcept { return static_cast<size_t>(right_ - left_); }
+
+    constexpr bool operator==(word_segmenter const& rhs) const noexcept
+    {
+        return (!codepointsAvailable() && !rhs.codepointsAvailable()) || (left_ == rhs.left_ && right_ == rhs.right_);
+    }
+
+  private:
+    char32_t const* left_;
+    char32_t const* right_;
+    char32_t const* end_;
+    word_segmenter_state state_;
 };
 
 } // namespace unicode

--- a/src/libunicode/word_segmenter_test.cpp
+++ b/src/libunicode/word_segmenter_test.cpp
@@ -1,5 +1,5 @@
 /**
- * This file is part of the "libterminal" project
+ * This file is part of the "libunicode" project
  *   Copyright (c) 2020 Christian Parpart <christian@parpart.family>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,27 +15,387 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
 using namespace unicode;
-using namespace std::string_literals;
-using namespace std;
+using namespace std::string_view_literals;
 
-TEST_CASE("word_segmenter.HelloWorld", "[word_segmenter]")
+namespace
 {
-    auto constexpr s = U"Hello, \t World!"sv;
+/// Collects all word segments from a u32string_view into a vector.
+std::vector<std::u32string_view> collect_segments(std::u32string_view text)
+{
+    std::vector<std::u32string_view> result;
+    auto seg = word_segmenter(text);
+    while (true)
+    {
+        auto const word = *seg;
+        if (word.empty() && !seg.codepointsAvailable())
+            break;
+        result.push_back(word);
+        if (!seg.codepointsAvailable())
+            break;
+        ++seg;
+    }
+    return result;
+}
 
-    auto ws = word_segmenter(s);
-    CHECK(*ws == U"Hello,");
-    CHECK(ws.size() == 6);
+/// Collects break positions (offsets from start) for a codepoint sequence.
+/// Returns a sorted list of offsets where word boundaries occur.
+/// Includes position 0 (sot) and position N (eot).
+std::vector<size_t> collect_break_positions(std::u32string_view text)
+{
+    std::vector<size_t> breaks;
+    breaks.push_back(0); // WB1: sot
 
-    ++ws;
-    CHECK(*ws == U" \t ");
-    CHECK(ws.size() == 3);
+    if (text.empty())
+        return breaks;
 
-    ++ws;
-    CHECK(*ws == U"World!");
-    CHECK(ws.size() == 6);
+    auto seg = word_segmenter(text);
+    size_t offset = 0;
+    while (true)
+    {
+        auto const word = *seg;
+        offset += word.size();
+        breaks.push_back(offset);
+        if (!seg.codepointsAvailable())
+            break;
+        ++seg;
+    }
+    return breaks;
+}
 
-    ++ws;
-    CHECK(*ws == U"");
-    CHECK(ws.size() == 0);
+/// Parse a hex string like "000D" to a char32_t.
+char32_t parse_hex(std::string_view sv)
+{
+    unsigned long val = 0;
+    for (auto c: sv)
+    {
+        val <<= 4;
+        if (c >= '0' && c <= '9')
+            val |= static_cast<unsigned long>(c - '0');
+        else if (c >= 'A' && c <= 'F')
+            val |= static_cast<unsigned long>(c - 'A' + 10);
+        else if (c >= 'a' && c <= 'f')
+            val |= static_cast<unsigned long>(c - 'a' + 10);
+    }
+    return static_cast<char32_t>(val);
+}
+
+struct WordBreakTestCase
+{
+    std::u32string codepoints;
+    std::vector<size_t> expected_breaks; // offsets where breaks occur
+    std::string comment;
+    int line_number = 0;
+};
+
+/// Parse WordBreakTest.txt into test cases.
+/// Format: ÷ 000D × 000A ÷ (# comment)
+/// ÷ = break, × = no break
+std::vector<WordBreakTestCase> parse_word_break_test_file(std::string const& path)
+{
+    std::vector<WordBreakTestCase> cases;
+    std::ifstream file(path);
+    if (!file.is_open())
+        return cases;
+
+    std::string line;
+    auto lineNo = 0;
+    while (std::getline(file, line))
+    {
+        ++lineNo;
+        if (line.empty() || line[0] == '#')
+            continue;
+
+        // The line starts with ÷ or × characters (UTF-8 encoded)
+        // ÷ = U+00F7 (UTF-8: C3 B7), × = U+00D7 (UTF-8: C3 97)
+
+        WordBreakTestCase tc;
+        tc.line_number = lineNo;
+
+        // Extract comment part
+        auto commentPos = line.find('#');
+        auto dataStr = (commentPos != std::string::npos) ? line.substr(0, commentPos) : line;
+        if (commentPos != std::string::npos)
+            tc.comment = line.substr(commentPos);
+
+        // Parse the data portion: sequence of (÷|×) XXXX pairs
+        size_t cpIndex = 0;
+        auto i = size_t { 0 };
+        while (i < dataStr.size())
+        {
+            // Skip whitespace
+            while (i < dataStr.size() && (dataStr[i] == ' ' || dataStr[i] == '\t'))
+                ++i;
+            if (i >= dataStr.size())
+                break;
+
+            // Check for ÷ (C3 B7) or × (C3 97)
+            if (i + 1 < dataStr.size() && static_cast<unsigned char>(dataStr[i]) == 0xC3)
+            {
+                auto const secondByte = static_cast<unsigned char>(dataStr[i + 1]);
+                if (secondByte == 0xB7) // ÷ = break
+                {
+                    tc.expected_breaks.push_back(cpIndex);
+                    i += 2;
+                    continue;
+                }
+                if (secondByte == 0x97) // × = no break
+                {
+                    i += 2;
+                    continue;
+                }
+            }
+
+            // Must be a hex codepoint
+            auto start = i;
+            while (i < dataStr.size() && dataStr[i] != ' ' && dataStr[i] != '\t'
+                   && static_cast<unsigned char>(dataStr[i]) != 0xC3)
+                ++i;
+
+            if (i > start)
+            {
+                auto hexStr = dataStr.substr(start, i - start);
+                tc.codepoints.push_back(parse_hex(hexStr));
+                ++cpIndex;
+            }
+        }
+
+        if (!tc.codepoints.empty())
+            cases.push_back(std::move(tc));
+    }
+    return cases;
+}
+} // namespace
+
+// =============================================================================
+// Official Unicode Conformance Tests
+// =============================================================================
+
+TEST_CASE("word_segmenter.unicode_conformance", "[word_segmenter]")
+{
+    auto const path = std::string(LIBUNICODE_UCD_DIR) + "/auxiliary/WordBreakTest.txt";
+    auto const testCases = parse_word_break_test_file(path);
+
+    if (testCases.empty())
+    {
+        WARN("Skipping conformance tests: WordBreakTest.txt not found at " << path);
+        return;
+    }
+    INFO("Loaded " << testCases.size() << " test cases from WordBreakTest.txt");
+
+    for (auto const& tc: testCases)
+    {
+        auto const actual = collect_break_positions(tc.codepoints);
+        if (actual != tc.expected_breaks)
+        {
+            std::ostringstream msg;
+            msg << "FAIL line " << tc.line_number << ": ";
+
+            msg << "codepoints: ";
+            for (auto cp: tc.codepoints)
+                msg << std::hex << "U+" << static_cast<uint32_t>(cp) << " ";
+
+            msg << " expected breaks: ";
+            for (auto b: tc.expected_breaks)
+                msg << std::dec << b << " ";
+
+            msg << " actual breaks: ";
+            for (auto b: actual)
+                msg << std::dec << b << " ";
+
+            msg << tc.comment;
+            FAIL(msg.str());
+        }
+    }
+}
+
+// =============================================================================
+// Manual Unit Tests
+// =============================================================================
+
+TEST_CASE("word_segmenter.empty", "[word_segmenter]")
+{
+    auto const segments = collect_segments(U""sv);
+    CHECK(segments.empty());
+}
+
+TEST_CASE("word_segmenter.basic_latin", "[word_segmenter]")
+{
+    // Each word and non-word character sequence forms a separate segment.
+    auto const segments = collect_segments(U"Hello World"sv);
+    REQUIRE(segments.size() == 3);
+    CHECK(segments[0] == U"Hello");
+    CHECK(segments[1] == U" ");
+    CHECK(segments[2] == U"World");
+}
+
+TEST_CASE("word_segmenter.punctuation_boundary", "[word_segmenter]")
+{
+    auto const segments = collect_segments(U"Hello, World!"sv);
+    // "Hello" | "," | " " | "World" | "!"
+    REQUIRE(segments.size() == 5);
+    CHECK(segments[0] == U"Hello");
+    CHECK(segments[1] == U",");
+    CHECK(segments[2] == U" ");
+    CHECK(segments[3] == U"World");
+    CHECK(segments[4] == U"!");
+}
+
+TEST_CASE("word_segmenter.contraction", "[word_segmenter]")
+{
+    // WB6/WB7: AHLetter (MidLetter|MidNumLetQ) AHLetter stays together
+    // Apostrophe (U+0027) has WB=Single_Quote, which is part of MidNumLetQ
+    auto const segments = collect_segments(U"don't"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"don't");
+}
+
+TEST_CASE("word_segmenter.numeric_with_separator", "[word_segmenter]")
+{
+    // WB11/WB12: Numeric (MidNum|MidNumLetQ) Numeric
+    // Period (U+002E) has WB=MidNumLet
+    auto const segments = collect_segments(U"3.14"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"3.14");
+}
+
+TEST_CASE("word_segmenter.crlf", "[word_segmenter]")
+{
+    // WB3: CR x LF (no break between them)
+    auto const segments = collect_segments(U"a\r\nb"sv);
+    REQUIRE(segments.size() == 3);
+    CHECK(segments[0] == U"a");
+    CHECK(segments[1] == U"\r\n");
+    CHECK(segments[2] == U"b");
+}
+
+TEST_CASE("word_segmenter.newline_break", "[word_segmenter]")
+{
+    // WB3a/WB3b: break around newlines
+    auto const segments = collect_segments(U"a\nb"sv);
+    REQUIRE(segments.size() == 3);
+    CHECK(segments[0] == U"a");
+    CHECK(segments[1] == U"\n");
+    CHECK(segments[2] == U"b");
+}
+
+TEST_CASE("word_segmenter.numeric_sequence", "[word_segmenter]")
+{
+    // WB8: Numeric x Numeric
+    auto const segments = collect_segments(U"12345"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"12345");
+}
+
+TEST_CASE("word_segmenter.letter_number_transition", "[word_segmenter]")
+{
+    // WB9: AHLetter x Numeric, WB10: Numeric x AHLetter
+    auto const segments = collect_segments(U"abc123def"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"abc123def");
+}
+
+TEST_CASE("word_segmenter.katakana", "[word_segmenter]")
+{
+    // WB13: Katakana x Katakana
+    // U+30AB = KATAKANA LETTER KA, U+30BF = KATAKANA LETTER TA, U+30CA = KATAKANA LETTER NA
+    auto const segments = collect_segments(U"\u30AB\u30BF\u30CA"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"\u30AB\u30BF\u30CA");
+}
+
+TEST_CASE("word_segmenter.extend_numlet", "[word_segmenter]")
+{
+    // WB13a/WB13b: ExtendNumLet connects letters, numbers, katakana
+    // U+005F = UNDERSCORE has WB=ExtendNumLet
+    auto const segments = collect_segments(U"hello_world"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"hello_world");
+}
+
+TEST_CASE("word_segmenter.wsegspace", "[word_segmenter]")
+{
+    // WB3d: WSegSpace x WSegSpace (multiple spaces stay together)
+    auto const segments = collect_segments(U"a   b"sv);
+    REQUIRE(segments.size() == 3);
+    CHECK(segments[0] == U"a");
+    CHECK(segments[1] == U"   ");
+    CHECK(segments[2] == U"b");
+}
+
+TEST_CASE("word_segmenter.regional_indicator_pair", "[word_segmenter]")
+{
+    // WB15/WB16: Regional Indicator pairs
+    // U+1F1FA U+1F1F8 = US flag (two RI characters)
+    auto const segments = collect_segments(U"\U0001F1FA\U0001F1F8"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"\U0001F1FA\U0001F1F8");
+}
+
+TEST_CASE("word_segmenter.regional_indicator_odd", "[word_segmenter]")
+{
+    // Three RI characters: first two pair, third is separate
+    auto const segments = collect_segments(U"\U0001F1FA\U0001F1F8\U0001F1EC"sv);
+    REQUIRE(segments.size() == 2);
+    CHECK(segments[0] == U"\U0001F1FA\U0001F1F8");
+    CHECK(segments[1] == U"\U0001F1EC");
+}
+
+TEST_CASE("word_segmenter.extend_transparency", "[word_segmenter]")
+{
+    // WB4: Extend characters are transparent
+    // U+0308 = COMBINING DIAERESIS (Extend)
+    // "a" + combining diaeresis + "b" should be: "a\u0308b" (one word, AHLetter x Extend x AHLetter)
+    auto const segments = collect_segments(U"a\u0308b"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"a\u0308b");
+}
+
+TEST_CASE("word_segmenter.hebrew_single_quote", "[word_segmenter]")
+{
+    // WB7a: Hebrew_Letter x Single_Quote
+    // U+05D0 = HEBREW LETTER ALEF (Hebrew_Letter)
+    auto const segments = collect_segments(U"\u05D0'"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"\u05D0'");
+}
+
+TEST_CASE("word_segmenter.hebrew_double_quote", "[word_segmenter]")
+{
+    // WB7b/WB7c: Hebrew_Letter x Double_Quote x Hebrew_Letter
+    // U+05D0 = HEBREW LETTER ALEF, U+0022 = QUOTATION MARK (Double_Quote)
+    auto const segments = collect_segments(U"\u05D0\"\u05D1"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"\u05D0\"\u05D1");
+}
+
+TEST_CASE("word_segmenter.emoji_zwj", "[word_segmenter]")
+{
+    // WB3c: ZWJ x Extended_Pictographic
+    // U+1F468 (man) + U+200D (ZWJ) + U+1F469 (woman) - ZWJ prevents break
+    auto const segments = collect_segments(U"\U0001F468\u200D\U0001F469"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"\U0001F468\u200D\U0001F469");
+}
+
+TEST_CASE("word_segmenter.codepointsAvailable", "[word_segmenter]")
+{
+    auto seg = word_segmenter(U"abc"sv);
+    CHECK_FALSE(seg.codepointsAvailable()); // "abc" is a single segment, no more after it
+    CHECK(static_cast<bool>(seg) == false);
+    CHECK(*seg == U"abc");
+}
+
+TEST_CASE("word_segmenter.single_char", "[word_segmenter]")
+{
+    auto const segments = collect_segments(U"a"sv);
+    REQUIRE(segments.size() == 1);
+    CHECK(segments[0] == U"a");
 }


### PR DESCRIPTION
- Replace the placeholder word_segmenter (simple whitespace splitting) with a full UAX #29 Word Boundary algorithm, implementing all rules WB1–WB999 with three-level state tracking, forward lookahead for mid-word punctuation rules, and WB4 Extend/Format/ZWJ transparency
- Wire Word_Break property into the UCD data pipeline: parse `WordBreakProperty.txt`, add `Word_Break` field to `codepoint_properties` (9→10 bytes), generate data in multistage tables; also fix `reverseLookup()` to correctly emit short enum names (CR, LF, L, V, T)
- Integrate into `to_titlecase()` and `is_case_ignorable()` for spec-correct behavior; all 1944 official Unicode `WordBreakTest.txt` conformance tests pass plus 20 targeted unit tests

Fixes #6