### PR TITLE
Fix SSE4.1/AVX flags not applied on FreeBSD (amd64)

### DIFF
--- a/src/libunicode/CMakeLists.txt
+++ b/src/libunicode/CMakeLists.txt
@@ -113,7 +113,13 @@ endif()
 
 
 if(LIBUNICODE_SIMD_IMPLEMENTATION STREQUAL "std" OR LIBUNICODE_SIMD_IMPLEMENTATION STREQUAL "intrinsics")
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
+    # Normalize the processor name: it is "x86_64" on Linux, "AMD64" on Windows,
+    # and "amd64" on FreeBSD/other BSDs. A case-sensitive match missed the BSD
+    # spelling, so the SSE4.1/AVX flags below were never applied while the x86
+    # intrinsics in intrinsics.h (gated on __x86_64__) were still compiled,
+    # breaking the FreeBSD build with always_inline SSE4.1 errors.
+    string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _LIBUNICODE_PROCESSOR_LOWER)
+    if(_LIBUNICODE_PROCESSOR_LOWER STREQUAL "x86_64" OR _LIBUNICODE_PROCESSOR_LOWER STREQUAL "amd64")
         set(LIBUNICODE_SIMD_SOURCES
             simd_detector.cpp
             scan256.cpp


### PR DESCRIPTION
The SIMD compile-flag block was guarded by a case-sensitive match on CMAKE_SYSTEM_PROCESSOR ("x86_64" or "AMD64"). FreeBSD (and other BSDs) report the processor as lowercase "amd64", so the block was skipped and -msse4.1 was never applied to convert.cpp. Because the x86 intrinsics in intrinsics.h are gated on __x86_64__ (always defined by clang on amd64), convert.cpp still compiled the SSE4.1 intrinsics, failing with:

  always_inline function '_mm_cvtepu8_epi32' requires target feature
  'sse4.1', but would be inlined into function 'cvtepu8_epi32' that is
  compiled without support for 'sse4.1'

Normalize CMAKE_SYSTEM_PROCESSOR to lowercase before comparing, matching x86_64/amd64 across Linux, Windows, and the BSDs.