### PR TITLE
Fix grapheme cluster widths that disagree with wcwidth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,47 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
 
 permissions:
   contents: write
 
 jobs:
+  create-release:
+    name: "Create draft release"
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: "Resolve release tag"
+        id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "tag=${INPUT_TAG:-$REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: "Create draft release"
+        env:
+          RELEASE_TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 \
+            || gh release create "$RELEASE_TAG" \
+                 --draft \
+                 --generate-notes \
+                 --title "libunicode ${RELEASE_TAG#v}"
+
   build:
+    needs: create-release
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +54,7 @@ jobs:
             artifact_name: unicode-query-macos-arm64
             binary_path: build/src/tools/unicode-query
             cmake_extra: ""
-          - os: macos-13
+          - os: macos-15-intel
             artifact_name: unicode-query-macos-x86_64
             binary_path: build/src/tools/unicode-query
             cmake_extra: ""
@@ -38,6 +71,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-release.outputs.tag }}
 
       - name: "Setup MSVC"
         if: runner.os == 'Windows'
@@ -88,7 +123,7 @@ jobs:
           path: ${{ matrix.artifact_name }}*
 
   release:
-    needs: build
+    needs: [create-release, build]
     runs-on: ubuntu-latest
     steps:
       - name: "Download all artifacts"
@@ -105,10 +140,11 @@ jobs:
 
       - name: "Generate checksums"
         working-directory: release
-        run: sha256sum * > SHA256SUMS
+        run: sha256sum unicode-query-* > SHA256SUMS
 
       - name: "Upload release assets"
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release upload --clobber "${{ github.event.release.tag_name }}" release/*
+          RELEASE_TAG: ${{ needs.create-release.outputs.tag }}
+        run: gh release upload --clobber "$RELEASE_TAG" release/*

--- a/src/libunicode/CMakeLists.txt
+++ b/src/libunicode/CMakeLists.txt
@@ -32,6 +32,44 @@ foreach(_gen_file IN LISTS _LIBUNICODE_GENERATED_FILES)
     endif()
 endforeach()
 
+# The generated files are build outputs that happen to land in the source tree, so "they exist"
+# alone is not evidence that they are current. If any tablegen source is newer than the oldest
+# generated file, an earlier build produced them from different rules and reusing them would compile
+# the library against a table that silently disagrees with its own generator -- a stale table cannot
+# fail the build, it only makes the tests wrong. Treat that as "not pregenerated" and regenerate.
+if(LIBUNICODE_HAS_PREGENERATED_FILES)
+    file(GLOB _LIBUNICODE_TABLEGEN_SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/tablegen/*.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tablegen/*.h"
+    )
+    foreach(_tablegen_source IN LISTS _LIBUNICODE_TABLEGEN_SOURCES)
+        foreach(_gen_file IN LISTS _LIBUNICODE_GENERATED_FILES)
+            # IS_NEWER_THAN is also true when the two timestamps are EQUAL, which is the normal case
+            # for a source tarball whose files were all unpacked at once. Asking in both directions
+            # makes this a strict comparison, so shipping the generated files alongside the generator
+            # does not force a needless UCD download on whoever builds from that tarball.
+            if("${_tablegen_source}" IS_NEWER_THAN "${_gen_file}"
+               AND NOT "${_gen_file}" IS_NEWER_THAN "${_tablegen_source}")
+                message(STATUS "[libunicode] ${_tablegen_source} is newer than generated sources; regenerating.")
+                set(LIBUNICODE_HAS_PREGENERATED_FILES FALSE)
+                break()
+            endif()
+        endforeach()
+        if(NOT LIBUNICODE_HAS_PREGENERATED_FILES)
+            break()
+        endif()
+    endforeach()
+endif()
+
+# Emscripten cannot run the generator it would need, so a stale table there is undetectable at build
+# time and ships as a wasm library whose widths disagree with the native one. Say so loudly.
+if(EMSCRIPTEN AND NOT LIBUNICODE_HAS_PREGENERATED_FILES)
+    message(WARNING
+        "[libunicode] Generated sources are out of date with respect to tablegen/, but tablegen "
+        "cannot run under Emscripten. Build natively once to refresh them, otherwise this wasm "
+        "build will use a table that does not match its generator.")
+endif()
+
 # Automatically fetch Unicode database if not present.
 # Skip download entirely when all generated files already exist on disk,
 # since neither mktables.py nor unicode_tablegen will need to run.

--- a/src/libunicode/capi.h
+++ b/src/libunicode/capi.h
@@ -95,19 +95,27 @@ extern "C"
     int u8_gc_count(u8_char_t const* codepoints, size_t n);
 
 /**
- * Determines that u32_gc_width()/u8_gc_width() must not respect
- * variation selectors, and thus, will not change the width of a
- * processed grapheme cluster.
+ * Measures every grapheme cluster by its BASE CODEPOINT ALONE.
  *
- * Using this is not recommended unless backwards compatibility with
- * broken clients is of concern.
+ * Nothing after the base is looked at: not variation selectors, and equally not
+ * spacing marks, viramas, emoji modifiers, ZWJ sequences or prepended format
+ * characters. Devanagari "ka + AA matra" is therefore reported as one column
+ * rather than two, and an emoji ZWJ sequence as the width of its first codepoint.
+ *
+ * This is NOT the width a terminal should reserve cells with, and it agrees
+ * neither with unicode::grapheme_cluster_width() nor with wcwidth. Using it is
+ * not recommended unless backwards compatibility with broken clients is of
+ * concern.
  */
 #define GC_WIDTH_MODE_NON_MODIFIABLE 0
 
 /**
- * Mandates that u32_gc_width()/u8_gc_width() must respect
- * variation selectors, thus, allow changing the width of
- * a processed grapheme cluster.
+ * Measures every grapheme cluster as a whole, the way
+ * unicode::grapheme_cluster_width() does, so that later members of the cluster
+ * contribute: variation selectors, spacing marks, viramas, emoji modifiers and
+ * ZWJ sequences are all accounted for.
+ *
+ * This is the mode a renderer wants, and the one scan_text() agrees with.
  */
 #define GC_WIDTH_MODE_MODIFIABLE 1
 
@@ -117,11 +125,11 @@ extern "C"
      *
      * @param codepoints  pointer to first codepoint
      * @param n           number of codepoints
-     * @param mode        determines how to deal with variation selectors that do
-     *                    force changing the width or a grapheme cluster.
+     * @param mode        determines whether a grapheme cluster is measured as a
+     *                    whole or by its base codepoint alone.
      *                    Valid values are:
-     *                    GC_WIDTH_MODE_MODIFIABLE (allow, recommended),
-     *                    GC_WIDTH_MODE_NON_MODIFIABLE (disallowed).
+     *                    GC_WIDTH_MODE_MODIFIABLE (whole cluster, recommended),
+     *                    GC_WIDTH_MODE_NON_MODIFIABLE (base codepoint only, legacy).
      *
      * Use this function to determine how many terminal grid cells a
      * string of codepoints should occupy when being rendered.

--- a/src/libunicode/codepoint_properties.h
+++ b/src/libunicode/codepoint_properties.h
@@ -27,6 +27,7 @@ struct LIBUNICODE_PACKED codepoint_properties
 {
     uint8_t char_width = 0;
     uint8_t flags = 0;
+    uint8_t flags2 = 0;
     Script script = Script::Unknown;
     Grapheme_Cluster_Break grapheme_cluster_break = Grapheme_Cluster_Break::Other;
     East_Asian_Width east_asian_width = East_Asian_Width::Narrow;
@@ -45,6 +46,9 @@ struct LIBUNICODE_PACKED codepoint_properties
     static uint8_t constexpr FlagCoreGraphemeExtend = 0x40;   // NOLINT(readability-identifier-naming)
     static uint8_t constexpr FlagVirama = 0x80;               // NOLINT(readability-identifier-naming)
 
+    // `flags` is exhausted; further single-bit properties live in `flags2`.
+    static uint8_t constexpr Flag2EmojiVariationBase = 0x01; // NOLINT(readability-identifier-naming)
+
     constexpr bool is_emoji() const noexcept { return flags & FlagEmoji; }
     constexpr bool is_emoji_presentation() const noexcept { return flags & FlagEmojiPresentation; }
     constexpr bool is_emoji_component() const noexcept { return flags & FlagEmojiComponent; }
@@ -53,11 +57,24 @@ struct LIBUNICODE_PACKED codepoint_properties
     constexpr bool is_extended_pictographic() const noexcept { return flags & FlagExtendedPictographic; }
     constexpr bool is_core_grapheme_extend() const noexcept { return flags & FlagCoreGraphemeExtend; }
 
-    /// Indic_Syllabic_Category=Virama: a codepoint that suppresses the inherent vowel of the
-    /// consonant it follows, joining it to the next into a conjunct.
+    /// Whether an emoji variation sequence is defined for this codepoint, i.e. whether a following
+    /// VS15 or VS16 is defined to re-present it.
     ///
-    /// Deliberately the FULL virama set rather than Indic_Conjunct_Break=Linker, which is restricted
-    /// to six scripts and would exclude Khmer, Myanmar, Javanese, Chakma and Tai Tham.
+    /// Which of the two selectors has an effect follows from this codepoint's own width: a base that
+    /// is one column wide is what VS16 widens, and one that is two columns wide is what VS15
+    /// narrows. Together those two subsets reproduce wcwidth's VS16_NARROW_TO_WIDE and
+    /// VS15_WIDE_TO_NARROW tables exactly.
+    constexpr bool is_emoji_variation_base() const noexcept { return flags2 & Flag2EmojiVariationBase; }
+
+    /// Indic_Syllabic_Category=Virama or =Invisible_Stacker: a codepoint that suppresses the
+    /// inherent vowel of the consonant it follows, joining it to the next into a conjunct.
+    ///
+    /// Deliberately the FULL virama set rather than Indic_Conjunct_Break=Linker. Linker is not
+    /// script-limited the way it is sometimes described -- in UCD 17.0 it already covers Khmer,
+    /// Myanmar, Javanese, Chakma and Tai Tham -- but it is a smaller set: 20 codepoints against 41.
+    /// The 21 it omits are viramas that do not form InCB conjuncts, among them Gurmukhi U+0A4D,
+    /// Tamil U+0BCD, Kannada U+0CCD, Sinhala U+0DCA and the Brahmi-family stackers. They still
+    /// stack a consonant onto the previous one, so they still widen the cluster.
     constexpr bool is_virama() const noexcept { return flags & FlagVirama; }
 
     using tables_view = support::multistage_table_view<codepoint_properties,

--- a/src/libunicode/scan.cpp
+++ b/src/libunicode/scan.cpp
@@ -89,15 +89,26 @@ scan_result detail::scan_for_text_nonascii(scan_state& state,
     char const* end = start + text.size();
     char const* input = start;
     char const* clusterStart = start;
-    char const* lastCodepointStart = start;
 
-    unsigned byteCount = 0; // bytes consume for the current codepoint
+    unsigned byteCount = 0; // bytes consumed for the current codepoint
 
-    // TODO: move currentClusterWidth to scan_state.
-    size_t currentClusterWidth = 0; // current grapheme cluster's East Asian Width
+    // How much of the open cluster's width THIS call has contributed. The cluster may have been
+    // opened by an earlier call, whose columns are already spent and cannot be taken back here, so
+    // this -- not state.reportedClusterWidth -- bounds what a rewind may subtract from count.
+    size_t clusterWidthCountedHere = 0;
 
     char const* resultStart = state.utf8.expectedLength ? start - state.utf8.currentLength : start;
     char const* resultEnd = resultStart;
+
+    // Hands over the cluster spanning [clusterStart, clusterEnd). Called at every cluster boundary
+    // and once more when the scan ends, so the last cluster is not dropped. A cluster put back
+    // because it did not fit leaves the range empty and is correctly not delivered.
+    auto const flushOpenCluster = [&](char const* clusterEnd) noexcept {
+        if (clusterEnd > clusterStart)
+            receiver.receiveGraphemeCluster(string_view(clusterStart, static_cast<size_t>(clusterEnd - clusterStart)),
+                                            state.reportedClusterWidth);
+        clusterStart = clusterEnd;
+    };
 
     while (input != end && count <= maxColumnCount)
     {
@@ -107,6 +118,9 @@ scan_result detail::scan_for_text_nonascii(scan_state& state,
         // part of its multi-byte codepoint.
         if (is_control(*input) || !is_complex(*input) || (state.utf8.expectedLength == 0 && is_c1_control(*input)))
         {
+            // A control ends whatever cluster was open, so hand it over before dropping the state.
+            flushOpenCluster(input);
+
             // Incomplete UTF-8 sequence hit. That's invalid as well.
             if (state.utf8.expectedLength)
             {
@@ -116,6 +130,8 @@ scan_result detail::scan_for_text_nonascii(scan_state& state,
             }
             state.lastCodepointHint = 0;
             state.graphemeState = {};
+            state.clusterWidth.reset();
+            state.reportedClusterWidth = 0;
             resultEnd = input;
             break;
         }
@@ -130,7 +146,8 @@ scan_result detail::scan_for_text_nonascii(scan_state& state,
         {
             auto const prevCodepoint = state.lastCodepointHint;
             auto const nextCodepoint = get<Success>(result).value;
-            auto const nextWidth = max(currentClusterWidth, static_cast<size_t>(width(nextCodepoint)));
+            char const* const codepointStart = input - byteCount;
+            byteCount = 0;
             state.lastCodepointHint = nextCodepoint;
 
             bool const breakable = [&] {
@@ -143,58 +160,82 @@ scan_result detail::scan_for_text_nonascii(scan_state& state,
             }();
             if (breakable)
             {
-                // Flush out current grapheme cluster's East Asian Width.
-                count += currentClusterWidth;
+                // The incoming codepoint opens the next cluster, so it is measured on its own rather
+                // than carrying anything over from the cluster just closed.
+                auto nextCluster = grapheme_cluster_width_accumulator {};
+                nextCluster.push(nextCodepoint);
+                auto const nextWidth = static_cast<size_t>(nextCluster.width());
 
                 if (count + nextWidth > maxColumnCount)
                 {
-                    // Currently scanned grapheme cluster won't fit. Break at start.
-                    currentClusterWidth = 0;
-                    input -= byteCount;
+                    // Currently scanned grapheme cluster won't fit. Break at its start.
+                    input = codepointStart;
                     break;
                 }
-                receiver.receiveGraphemeCluster(string_view(clusterStart, byteCount), currentClusterWidth);
 
-                // And start a new grapheme cluster.
-                currentClusterWidth = nextWidth;
-                clusterStart = lastCodepointStart;
-                lastCodepointStart = input - byteCount;
-                byteCount = 0;
+                // The cluster that just ended spans everything up to this codepoint.
+                flushOpenCluster(codepointStart);
+
+                count += nextWidth;
+                clusterWidthCountedHere = nextWidth;
+                state.clusterWidth = nextCluster;
+                state.reportedClusterWidth = nextWidth;
                 resultEnd = input;
             }
             else
             {
-                resultEnd = input;
-                // Increase width on VS16 but do not decrease on VS15.
-                if (nextCodepoint == 0xFE0F) // VS16
+                // The codepoint joins the current cluster, which may widen it (a spacing mark, a
+                // conjunct, VS16) or narrow it (VS15). Only the difference is counted, so a cluster
+                // split across two calls is not measured twice.
+                state.clusterWidth.push(nextCodepoint);
+                auto const updatedWidth = static_cast<size_t>(state.clusterWidth.width());
+
+                if (updatedWidth >= state.reportedClusterWidth)
                 {
-                    currentClusterWidth = 2;
-                    if (count + currentClusterWidth > maxColumnCount)
+                    auto const added = updatedWidth - state.reportedClusterWidth;
+                    if (added != 0 && count + added > maxColumnCount)
                     {
-                        // Rewinding by {byteCount} bytes (overflow due to VS16).
-                        currentClusterWidth = 0;
+                        // The cluster grew past what is left of the line. Put the whole cluster
+                        // back -- a caller cannot render part of one -- and un-count only what this
+                        // call contributed to it.
+                        count -= clusterWidthCountedHere;
                         input = clusterStart;
+                        resultEnd = clusterStart;
+                        state.clusterWidth.reset();
+                        state.reportedClusterWidth = 0;
                         break;
                     }
+                    count += added;
+                    clusterWidthCountedHere += added;
                 }
-
-                // Consumed {byteCount} bytes for grapheme cluster.
-                lastCodepointStart = input - byteCount;
+                else
+                {
+                    auto const removed = min(state.reportedClusterWidth - updatedWidth, clusterWidthCountedHere);
+                    count -= removed;
+                    clusterWidthCountedHere -= removed;
+                }
+                state.reportedClusterWidth = updatedWidth;
+                resultEnd = input;
             }
         }
         else
         {
             assert(holds_alternative<Invalid>(result));
+            flushOpenCluster(input - byteCount);
             count++;
             receiver.receiveInvalidGraphemeCluster();
-            currentClusterWidth = 0;
+            clusterWidthCountedHere = 0;
+            state.clusterWidth.reset();
+            state.reportedClusterWidth = 0;
             state.lastCodepointHint = 0;
             state.graphemeState = {};
             state.utf8.expectedLength = 0;
             byteCount = 0;
         }
     }
-    count += currentClusterWidth;
+
+    // Hand over whatever cluster the scan ended inside of.
+    flushOpenCluster(input);
 
     assert(resultStart <= resultEnd);
 
@@ -252,6 +293,20 @@ scan_result scan_text(scan_state& state,
                 if (!count)
                     return result;
                 receiver.receiveAsciiSequence(text.substr(0, count));
+
+                // A cluster does not have to respect the boundary between the two scanners: the last
+                // character of this run may be the base of one that continues into the non-ASCII
+                // bytes behind it, as `a` does in "a<visarga>". Seed the segmenter and the width
+                // accumulator with it so the scan below joins the two instead of treating the mark
+                // as opening a fresh cluster -- and record the one column already counted for it, so
+                // only what the mark adds is counted a second time.
+                auto const lastAscii = static_cast<char32_t>(static_cast<uint8_t>(text[count - 1]));
+                state.lastCodepointHint = lastAscii;
+                grapheme_process_init(lastAscii, state.graphemeState);
+                state.clusterWidth.reset();
+                state.clusterWidth.push(lastAscii);
+                state.reportedClusterWidth = 1;
+
                 result.count += count;
                 state.next += count;
                 result.end += count;

--- a/src/libunicode/scan.h
+++ b/src/libunicode/scan.h
@@ -15,6 +15,7 @@
 
 #include <libunicode/grapheme_segmenter.h>
 #include <libunicode/utf8.h>
+#include <libunicode/width.h>
 
 #include <string_view>
 
@@ -47,6 +48,19 @@ struct scan_state
     utf8_decoder_state utf8 {};
     char32_t lastCodepointHint {};
     grapheme_segmenter_state graphemeState {};
+
+    /// Measures the grapheme cluster currently being scanned.
+    ///
+    /// This belongs to the state rather than to scan_text()'s frame because a cluster may straddle
+    /// two calls, and it has to stay in step with graphemeState above: measuring the second half of
+    /// a cluster with a fresh accumulator loses whatever the first half contributed.
+    grapheme_cluster_width_accumulator clusterWidth {};
+
+    /// Columns already reported for the cluster clusterWidth is measuring.
+    ///
+    /// A cluster that grows contributes only the difference, so the counts returned by a sequence of
+    /// calls stay additive no matter where the chunk boundaries fall.
+    size_t reportedClusterWidth {};
 
     /// Pointer to one byte after the last scanned codepoint.
     char const* next {};

--- a/src/libunicode/scan_test.cpp
+++ b/src/libunicode/scan_test.cpp
@@ -14,11 +14,15 @@
 #include <libunicode/convert.h>
 #include <libunicode/scan.h>
 #include <libunicode/utf8.h>
+#include <libunicode/width.h>
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
 #include <format>
+#include <string>
 #include <string_view>
+#include <vector>
 
 using std::string_view;
 
@@ -331,6 +335,166 @@ TEST_CASE("scan.complex.VS16")
     auto const result3 = unicode::scan_text(state, s, 1);
     CHECK(result3.count == 0);
     CHECK(state.next == s.data());
+}
+
+TEST_CASE("scan.width_agrees_with_grapheme_cluster_width")
+{
+    // scan_text() and grapheme_cluster_width() are the library's two ways of asking how wide a piece
+    // of text is, and they must never answer differently: a terminal scans with the former to advance
+    // the cursor and measures with the latter when laying out, so any disagreement draws text at a
+    // different width than was reserved for it and corrupts the rest of the line.
+    auto const cases = std::array {
+        U"का"sv,                   // Devanagari ka + AA matra (spacing mark)
+        U"क्न"sv,                   // ka + virama + na (conjunct)
+        U"กำ"sv,                   // Thai ko kai + sara am
+        U"ຠຳ"sv,                   // Lao pho + sign AM
+        U"ក្រ"sv,                   // Khmer conjunct (Invisible_Stacker)
+        U"©️"sv,                    // copyright + VS16 (a defined variation base)
+        U"✓️"sv,                    // check mark + VS16 (NOT a variation base)
+        U"⌚︎"sv,                   // watch + VS15
+        U"漢︎"sv,                   // CJK ideograph + VS15 (must not narrow)
+        U"❤\U0001F3FB"sv,          // heart + skin tone modifier
+        U"❤‍\U0001F525"sv,     // heart ZWJ fire
+        U"\U0001F1E9\U0001F1EA"sv, // regional indicator pair
+        U"中é"sv,                  // wide then narrow: the narrow one must not inherit width 2
+        U"中éé"sv,                 // ...and the error must not compound
+        U"\U0001F600é"sv,          // emoji then narrow
+        U"中α"sv,                  // CJK then Greek alpha
+        U"❤‍A"sv,              // heart ZWJ 'A': GB11 does not join, so this is two clusters
+    };
+
+    for (auto const cluster: cases)
+    {
+        auto const utf8 = u8(cluster);
+        auto state = unicode::scan_state {};
+        auto const scanned = unicode::scan_text(state, utf8, 80);
+        INFO("cluster: " << escape(utf8));
+        // The oracle is the std::string_view overload, which segments. The u32string_view one does
+        // not -- it is documented as taking a *single* cluster -- and several cases above are two,
+        // so measuring them with it would let a ZWJ swallow the codepoint across a cluster boundary
+        // and report on the oracle rather than on scan_text().
+        CHECK(scanned.count == unicode::grapheme_cluster_width(utf8));
+    }
+}
+
+TEST_CASE("scan.cluster_split_across_calls_is_measured_once")
+{
+    // A grapheme cluster that straddles two scan_text() calls must total exactly what the whole
+    // string totals: chunked input is how a terminal reads a PTY, so any drift here mis-advances the
+    // cursor on ordinary text.
+    //
+    // Regression: the width accumulator was a local of scan_for_text_nonascii() while the grapheme
+    // state it tracks lives in scan_state, so the second call started from an empty accumulator and
+    // the selector it carried widened nothing.
+    auto const text = u8(U"©️"sv); // copyright (2 bytes) + VS16 (3 bytes)
+    REQUIRE(text.size() == 5);
+
+    auto state = unicode::scan_state {};
+    auto const first = unicode::scan_text(state, string_view(text.data(), 2), 80);
+    auto const rest = string_view(state.next, static_cast<size_t>(std::distance(state.next, text.data() + text.size())));
+    auto const second = unicode::scan_text(state, rest, 80);
+
+    CHECK(first.count + second.count == unicode::grapheme_cluster_width(text));
+    CHECK(first.count + second.count == 2);
+    CHECK(state.next == text.data() + text.size());
+}
+
+TEST_CASE("scan.growing_cluster_does_not_overrun_the_scan_end")
+{
+    // scan_text() promises result.end <= state.next. The overflow rewind used to reset the input
+    // pointer to a cluster start that lagged one cluster behind while result.end had already
+    // advanced, so the caller was handed an end past what was scanned and re-rendered those bytes.
+    //
+    // The rewind was reachable only through VS16 before this path learned to honour spacing marks
+    // and conjuncts, which is why ordinary Devanagari now reaches it.
+    auto const text = u8(U"中काab"sv); // CJK + ka + AA matra + "ab"
+    auto state = unicode::scan_state {};
+    auto const result = unicode::scan_text(state, text, 3);
+
+    CHECK(result.start <= result.end);
+    CHECK(result.end <= state.next);
+
+    // 中 is two columns and का is two more, so only 中 fits in three.
+    CHECK(result.count == 2);
+    CHECK(result.end == text.data() + 3);
+}
+
+TEST_CASE("scan.ascii_base_carries_into_a_following_spacing_mark")
+{
+    // The ASCII fast path is a separate scanner, but a cluster does not have to respect that
+    // boundary: an ASCII base followed by a non-ASCII spacing mark is one cluster two columns wide.
+    // Regression: the fast path recorded no last codepoint, so the mark looked like the start of a
+    // fresh cluster and the pair measured 1.
+    struct Case
+    {
+        std::u32string_view text;
+        size_t expected;
+        std::string_view what;
+    };
+    auto const cases = std::array {
+        Case { U"aः"sv, 2, "a + Devanagari visarga" },
+        Case { U"aா"sv, 2, "a + Tamil AA matra" },
+        Case { U"abः"sv, 3, "trailing ASCII char is the base" },
+        Case { U"abc"sv, 3, "pure ASCII still counts every column" },
+        Case { U"ab中"sv, 4, "ASCII then a wide char that opens its own cluster" },
+    };
+
+    for (auto const& testCase: cases)
+    {
+        auto const utf8 = u8(testCase.text);
+        auto state = unicode::scan_state {};
+        auto const result = unicode::scan_text(state, utf8, 80);
+        INFO(testCase.what);
+        CHECK(result.count == testCase.expected);
+        CHECK(result.count == unicode::grapheme_cluster_width(utf8));
+    }
+}
+
+namespace
+{
+struct cluster_collector final: public unicode::grapheme_cluster_receiver
+{
+    std::vector<std::string> clusters;
+    std::vector<size_t> widths;
+
+    void receiveAsciiSequence(std::string_view text) noexcept override
+    {
+        for (auto const ch: text)
+        {
+            clusters.emplace_back(1, ch);
+            widths.push_back(1);
+        }
+    }
+    void receiveGraphemeCluster(std::string_view text, size_t columnCount) noexcept override
+    {
+        clusters.emplace_back(text);
+        widths.push_back(columnCount);
+    }
+    void receiveInvalidGraphemeCluster() noexcept override
+    {
+        clusters.emplace_back("<invalid>");
+        widths.push_back(1);
+    }
+};
+} // namespace
+
+TEST_CASE("scan.receiver_gets_whole_clusters")
+{
+    // Regression: the byte count handed to receiveGraphemeCluster() was reset only *after* the call,
+    // so each cluster was delivered with the byte length of the next cluster's first codepoint --
+    // truncated UTF-8 whenever the two differ in length, and the final cluster was dropped entirely.
+    // Clusters of equal byte length hid it, which is all the older tests used.
+    auto const text = u8(U"中é"sv); // CJK (3 bytes) + e-acute (2 bytes)
+    auto collector = cluster_collector {};
+    auto state = unicode::scan_state {};
+    auto const result = unicode::scan_text(state, text, 80, collector);
+
+    CHECK(result.count == 3);
+    REQUIRE(collector.clusters.size() == 2);
+    CHECK(collector.clusters[0] == u8(U"中"sv));
+    CHECK(collector.clusters[1] == u8(U"é"sv));
+    CHECK(collector.widths[0] == 2);
+    CHECK(collector.widths[1] == 1);
 }
 
 TEST_CASE("scan.c1_control.stops_mid_run")

--- a/src/libunicode/tablegen/multistage_generator.cpp
+++ b/src/libunicode/tablegen/multistage_generator.cpp
@@ -49,6 +49,9 @@ namespace
     constexpr uint8_t FlagCoreGraphemeExtend = 0x40;
     constexpr uint8_t FlagVirama = 0x80;
 
+    // `flags` is exhausted; further single-bit properties live in `flags2`.
+    constexpr uint8_t Flag2EmojiVariationBase = 0x01;
+
     // EmojiSegmentationCategory integer values, must match the enum
     constexpr int8_t ESC_Invalid = -1;
     constexpr int8_t ESC_Emoji = 0;
@@ -74,6 +77,7 @@ namespace
     {
         uint8_t char_width = 0;
         uint8_t flags = 0;
+        uint8_t flags2 = 0;
         uint8_t script = 0;                 // Will be set per-codepoint
         uint8_t grapheme_cluster_break = 0; // Will be set per-codepoint
         uint8_t east_asian_width = 0;       // Will be set per-codepoint
@@ -85,7 +89,7 @@ namespace
     };
 #pragma pack(pop)
 
-    static_assert(sizeof(CodepointRecord) == 10, "CodepointRecord must be exactly 10 bytes");
+    static_assert(sizeof(CodepointRecord) == 11, "CodepointRecord must be exactly 11 bytes");
 
     inline bool operator==(CodepointRecord const& a, CodepointRecord const& b) noexcept
     {
@@ -427,16 +431,27 @@ void generateMultistageFiles(UcdParser const& parser, std::string const& outputD
 
     // IndicSyllabicCategory (Virama flag)
     //
-    // The FULL virama set, deliberately, rather than Indic_Conjunct_Break=Linker: that covers only
-    // six scripts and would leave Khmer, Myanmar, Javanese, Chakma and Tai Tham conjuncts unmarked.
+    // The FULL virama set, deliberately, rather than Indic_Conjunct_Break=Linker. Linker is not
+    // restricted to a handful of scripts -- in UCD 17.0 it already covers Khmer, Myanmar, Javanese,
+    // Chakma and Tai Tham -- but it is a smaller set: 20 codepoints against 41. The 21 it leaves out
+    // are viramas that do not form InCB conjuncts, among them Gurmukhi U+0A4D, Tamil U+0BCD,
+    // Kannada U+0CCD, Sinhala U+0DCA and the Brahmi-family stackers. They still stack a consonant
+    // onto the previous one, so they still widen the cluster.
     //
     // Invisible_Stacker is included because it IS a virama for measuring purposes -- Khmer U+17D2,
     // Myanmar U+1039, Chakma U+11133 and Tai Tham U+1A60 stack a consonant onto the previous one
     // exactly as a Virama does, and are only categorised apart because they are never rendered.
+    //
+    // Together this reproduces wcwidth's _ISC_VIRAMA_SET exactly (41 codepoints).
     for (auto const& r: parser.indicSyllabicCategory())
         if (r.property == "Virama" || r.property == "Invisible_Stacker")
-            for (auto cp = r.first; cp <= r.last; ++cp)
+            for (auto cp = r.first; cp <= r.last && cp < CODEPOINT_COUNT; ++cp)
                 records[static_cast<size_t>(cp)].flags |= FlagVirama;
+
+    // Emoji variation sequence bases: the codepoints a following VS15/VS16 is defined to re-present.
+    for (auto const cp: parser.emojiVariationBases())
+        if (cp < CODEPOINT_COUNT)
+            records[static_cast<size_t>(cp)].flags2 |= Flag2EmojiVariationBase;
 
     // DerivedAge
     for (auto const& r: parser.ageRanges())
@@ -562,34 +577,33 @@ void generateMultistageFiles(UcdParser const& parser, std::string const& outputD
     //
     // General_Category=Cf is zero-width as a rule, and for the invisible ones -- ZWJ, ZWNJ, the
     // bidi marks, BOM -- that is right. But a handful of Cf codepoints do draw something: the Arabic
-    // prepended concatenation marks (U+0600..U+0605, U+06DD, U+0890, U+0891, U+08E2), SOFT HYPHEN,
-    // U+070F, and the Kaithi number signs. Default_Ignorable_Code_Point is exactly the property that
-    // separates the two groups, and Python wcwidth measures the rendered ones as one column.
+    // prepended concatenation marks (U+0600..U+0605, U+06DD, U+0890, U+0891, U+08E2), U+070F, and
+    // the Kaithi number signs (U+110BD, U+110CD). What they have in common is Grapheme_Cluster_Break
+    // =Prepend: they attach to and are drawn before the cluster that follows.
+    //
+    // Default_Ignorable_Code_Point looks like it separates the same two groups but is 19 codepoints
+    // too generous: the interlinear annotation marks U+FFF9..U+FFFB and the Egyptian hieroglyph
+    // format controls U+13430..U+1343F are Cf, are not Default_Ignorable, and still render nothing.
+    // Python wcwidth measures those as zero. Cf AND Prepend reproduces wcwidth's set exactly.
     {
-        auto defaultIgnorable = std::vector<bool>(CODEPOINT_COUNT, false);
-        if (auto const it = parser.coreProperties().find("Default_Ignorable_Code_Point"); it != parser.coreProperties().end())
-        {
-            for (auto const& r: it->second)
-                for (auto cp = r.first; cp <= r.last; ++cp)
-                    defaultIgnorable[static_cast<size_t>(cp)] = true;
-        }
+        auto prepend = std::vector<bool>(CODEPOINT_COUNT, false);
+        for (auto const& [_, ranges]: parser.graphemeBreakProps())
+            for (auto const& r: ranges)
+                if (r.property == "Prepend")
+                    for (auto cp = r.first; cp <= r.last && cp < CODEPOINT_COUNT; ++cp)
+                        prepend[static_cast<size_t>(cp)] = true;
 
-        auto gcFormat = uint8_t { 0 };
-        auto haveFormat = false;
         if (auto const it = gcIndex.find("Format"); it != gcIndex.end())
         {
-            gcFormat = it->second;
-            haveFormat = true;
+            auto const gcFormat = it->second;
+            for (char32_t cp = 0; cp < CODEPOINT_COUNT; ++cp)
+                if (records[static_cast<size_t>(cp)].general_category == gcFormat && prepend[static_cast<size_t>(cp)])
+                    records[static_cast<size_t>(cp)].char_width = 1;
         }
 
-        if (haveFormat)
-            for (char32_t cp = 0; cp < CODEPOINT_COUNT; ++cp)
-                if (records[static_cast<size_t>(cp)].general_category == gcFormat && !defaultIgnorable[static_cast<size_t>(cp)])
-                    records[static_cast<size_t>(cp)].char_width = 1;
-
-        // U+00AD SOFT HYPHEN is Default_Ignorable, so the rule above misses it, yet a terminal has
-        // no line breaking to hide it with and draws it as a hyphen. Windows Terminal carves it out
-        // for the same reason and cites wcswidth in doing so.
+        // U+00AD SOFT HYPHEN is Cf but not Prepend, so the rule above misses it, yet a terminal has
+        // no line breaking to hide it with and draws it as a hyphen. wcwidth measures it as one
+        // column for the same reason; Windows Terminal carves it out likewise.
         records[0x00AD].char_width = 1;
     }
 
@@ -675,6 +689,7 @@ void generateMultistageFiles(UcdParser const& parser, std::string const& outputD
     for (auto const& rec: propsTable.stage3)
     {
         impl << "    {" << static_cast<unsigned>(rec.char_width) << ", " << (!rec.flags ? "0" : binstr(rec.flags)) << ", "
+             << (!rec.flags2 ? "0" : binstr(rec.flags2)) << ", "
              << "Script::" << (rec.script < scriptNames.size() ? scriptNames[rec.script] : "Unknown") << ", "
              << "Grapheme_Cluster_Break::" << reverseLookup(gcbIndex, rec.grapheme_cluster_break, "Other") << ", "
              << "East_Asian_Width::" << reverseLookup(eawIndex, rec.east_asian_width, "Narrow") << ", "

--- a/src/libunicode/tablegen/ucd_parser.cpp
+++ b/src/libunicode/tablegen/ucd_parser.cpp
@@ -124,6 +124,15 @@ namespace
             result.isRange = false;
         }
 
+        // Every caller turns these into `for (cp = first; cp <= last; ++cp) table[cp] = ...` over
+        // containers sized for the Unicode range. A malformed, truncated or hand-patched UCD file
+        // whose endpoints fall outside that range would write past the end of those containers and
+        // corrupt neighbouring table data -- silently, since the corrupted table still compiles.
+        // Reject such a line here rather than trusting every loop to bound-check itself.
+        constexpr auto lastCodepoint = char32_t { 0x10FFFF };
+        if (result.first > lastCodepoint || result.last > lastCodepoint || result.last < result.first)
+            return std::nullopt;
+
         return result;
     }
 
@@ -198,6 +207,7 @@ void UcdParser::parseAll()
     loadEastAsianWidths();
     loadHangulSyllableType();
     loadEmojiProps();
+    loadEmojiVariationSequences();
     loadBidiMirrored();
     loadBidiMirroringGlyph();
 
@@ -481,6 +491,41 @@ void UcdParser::loadEmojiProps()
     }
     for (auto& [key, ranges]: _emojiProps)
         std::sort(ranges.begin(), ranges.end(), [](auto const& a, auto const& b) { return a.first < b.first; });
+}
+
+// ---- Emoji Variation Sequences ----
+
+/// Collects the base codepoints of the emoji variation sequences, i.e. those a following VS15 or
+/// VS16 is defined to re-present. Lines look like:
+///
+///     231A FE0E  ; text style;  # (1.1) WATCH
+///     231A FE0F  ; emoji style; # (1.1) WATCH
+///
+/// Only the base is of interest here; which of the two selectors applies to a given base follows
+/// from the base's own width, so both spellings collapse to the same entry.
+void UcdParser::loadEmojiVariationSequences()
+{
+    auto f = openFile(_ucdDir + "/emoji/emoji-variation-sequences.txt");
+    std::string line;
+    while (std::getline(f, line))
+    {
+        if (auto const hash = line.find('#'); hash != std::string::npos)
+            line.erase(hash);
+        auto const semicolon = line.find(';');
+        if (semicolon == std::string::npos)
+            continue;
+
+        auto sequence = std::istringstream(line.substr(0, semicolon));
+        auto baseText = std::string {};
+        if (!(sequence >> baseText))
+            continue;
+
+        auto const base = static_cast<char32_t>(std::stoul(baseText, nullptr, 16));
+        _emojiVariationBases.push_back(base);
+    }
+
+    std::sort(_emojiVariationBases.begin(), _emojiVariationBases.end());
+    _emojiVariationBases.erase(std::unique(_emojiVariationBases.begin(), _emojiVariationBases.end()), _emojiVariationBases.end());
 }
 
 // ---- Bidi Mirrored ----

--- a/src/libunicode/tablegen/ucd_parser.h
+++ b/src/libunicode/tablegen/ucd_parser.h
@@ -132,6 +132,10 @@ class UcdParser
     /// Emoji properties grouped by property name.
     [[nodiscard]] auto const& emojiProps() const noexcept { return _emojiProps; }
 
+    /// Base codepoints that have an emoji variation sequence, i.e. that VS15 or VS16 can re-present.
+    /// Sorted and duplicate-free.
+    [[nodiscard]] auto const& emojiVariationBases() const noexcept { return _emojiVariationBases; }
+
     /// Bidi mirrored intervals (compressed).
     [[nodiscard]] auto const& bidiMirroredIntervals() const noexcept { return _bidiMirroredIntervals; }
 
@@ -185,6 +189,7 @@ class UcdParser
     void loadEastAsianWidths();
     void loadHangulSyllableType();
     void loadEmojiProps();
+    void loadEmojiVariationSequences();
     void loadBidiMirrored();
     void loadBidiMirroringGlyph();
 
@@ -248,6 +253,7 @@ class UcdParser
 
     // Emoji
     std::map<std::string, std::vector<PropertyRange>> _emojiProps;
+    std::vector<char32_t> _emojiVariationBases;
 
     // Bidi mirroring
     std::vector<std::pair<char32_t, char32_t>> _bidiMirroredIntervals;

--- a/src/libunicode/width.cpp
+++ b/src/libunicode/width.cpp
@@ -28,6 +28,132 @@ unsigned width(char32_t codepoint) noexcept
     return codepoint_properties::get(codepoint).char_width;
 }
 
+namespace
+{
+    /// wcwidth's _EMOJI_ZWJ_SET: every Extended_Pictographic plus the 26 regional indicators.
+    bool joinsEmojiSequence(char32_t codepoint) noexcept
+    {
+        auto const props = codepoint_properties::get(codepoint);
+        return props.is_extended_pictographic() || props.grapheme_cluster_break == Grapheme_Cluster_Break::Regional_Indicator;
+    }
+} // namespace
+
+void grapheme_cluster_width_accumulator::push(char32_t codepoint) noexcept
+{
+    auto const properties = codepoint_properties::get(codepoint);
+
+    // A flag is a PAIR of regional indicators rendered as one glyph, and which half this codepoint is
+    // depends on how many regional indicators sit *immediately* before it. That run length is
+    // therefore maintained for every codepoint, including the ones the branches below return early
+    // on: a variation selector or a ZWJ ends the run, so the indicator after it opens a new pair.
+    // wcwidth reads the run off the raw input rather than off what it processed, which is why even a
+    // codepoint that the ZWJ below swallows still counts toward it.
+    auto const regionalIndicatorsBefore = _regionalIndicators;
+    _regionalIndicators =
+        properties.grapheme_cluster_break == Grapheme_Cluster_Break::Regional_Indicator ? _regionalIndicators + 1 : 0;
+
+    // A ZWJ consumes the codepoint that follows it, which is why an emoji ZWJ sequence is measured
+    // by its first segment rather than by its widest member.
+    if (_skipNext)
+    {
+        _skipNext = false;
+        return;
+    }
+
+    if (codepoint == 0x200D) // ZWJ
+    {
+        // After a virama the ZWJ is merely a joining hint, so the consonant behind it must still be
+        // seen. A ZWJ that ends the cluster consumes nothing, which is what _skipNext expiring
+        // unused amounts to.
+        if (!_previousWasVirama)
+        {
+            _skipNext = true;
+            _lastMeasuredWidth = 0;
+        }
+        return;
+    }
+
+    // VS16 requests the emoji presentation, which is two columns -- but only for a base an emoji
+    // variation sequence is actually defined for. A variation selector after ordinary text (`x`, a
+    // bullet, an em dash) is not a presentation request and must not widen anything.
+    if (codepoint == 0xFE0F && _lastMeasuredIsOpen)
+    {
+        // The base's OWN width decides this, not the width recorded when it was measured: a ZWJ
+        // zeroes the latter, and wcwidth resolves VS16 purely by looking the base up in its
+        // narrow-to-wide table without consulting it. That table is encoded here as the variation
+        // base flag plus a base width of one.
+        if (auto const base = codepoint_properties::get(_lastMeasured); base.is_emoji_variation_base() && base.char_width == 1)
+            _current = 2;
+        _lastMeasuredIsOpen = false; // prevent a second application
+        return;
+    }
+
+    // VS15 requests the text presentation, which is one column. Again this is meaningful only for a
+    // defined variation base: it must not narrow a CJK ideograph, a Hangul jamo, or an Indic cluster
+    // that a spacing mark or a conjunct widened.
+    //
+    // Deliberately NOT symmetric with VS16 above, in two ways that both mirror wcwidth: this branch
+    // does read the recorded width (so a ZWJ that zeroed it suppresses the narrowing), and it does
+    // not mark the base consumed (so a repeated VS15 decrements again, underflowing the cluster to
+    // zero). Both are pinned by tests; see repeated_vs15_underflows_like_wcwidth.
+    if (codepoint == 0xFE0E && _lastMeasuredIsOpen)
+    {
+        if (codepoint_properties::get(_lastMeasured).is_emoji_variation_base() && _lastMeasuredWidth == 2)
+            --_total;
+        return;
+    }
+
+    // The second indicator of a pair is drawn into the flag the first one opened, so it adds nothing.
+    if (properties.grapheme_cluster_break == Grapheme_Cluster_Break::Regional_Indicator && regionalIndicatorsBefore % 2 == 1)
+    {
+        _lastMeasured = codepoint;
+        return;
+    }
+
+    // A skin tone modifier is absorbed by the emoji it modifies rather than placed beside it. The
+    // base need not be Emoji_Modifier_Base: an ill-formed but perfectly real sequence such as a
+    // heart or a copyright sign followed by a modifier still renders as one glyph.
+    if (codepoint >= 0x1F3FB && codepoint <= 0x1F3FF && joinsEmojiSequence(_lastMeasured))
+        return;
+
+    if (auto const w = static_cast<int>(properties.char_width); w != 0)
+    {
+        if (_previousWasVirama)
+            // A consonant joined to the previous one through a virama: the conjunct they form is
+            // wider than one cell, but never wider than two.
+            _current = 2;
+        else if (_current != 0)
+        {
+            _total += _current;
+            _current = w;
+        }
+        else
+            _current = w;
+
+        _lastMeasured = codepoint;
+        _lastMeasuredWidth = w;
+        _lastMeasuredIsOpen = true;
+        _previousWasVirama = false;
+    }
+    else if (properties.is_virama())
+        _previousWasVirama = true;
+    else if (properties.general_category == General_Category::Spacing_Mark && _lastMeasuredIsOpen)
+    {
+        // A spacing mark takes room of its own next to its base, unlike a non-spacing one.
+        _current = 2;
+        _lastMeasuredIsOpen = false;
+        _previousWasVirama = false;
+    }
+    else
+        _previousWasVirama = false;
+}
+
+unsigned grapheme_cluster_width_accumulator::width() const noexcept
+{
+    auto const total = _total + _current;
+    return total > 0 ? static_cast<unsigned>(total) : 0u;
+}
+
 unsigned grapheme_cluster_width(std::u32string_view cluster) noexcept
 {
     if (cluster.empty())
@@ -36,86 +162,10 @@ unsigned grapheme_cluster_width(std::u32string_view cluster) noexcept
     if (cluster.size() == 1)
         return width(cluster[0]);
 
-    auto total = 0u;   // width of the segments already closed off
-    auto current = 0u; // width of the segment being accumulated
-    auto previousWasVirama = false;
-    auto regionalIndicators = 0u;
-    auto previousIsEmojiModifierBase = false;
-
-    for (size_t i = 0; i < cluster.size(); ++i)
-    {
-        auto const cp = cluster[i];
-
-        // A flag is a PAIR of regional indicators rendered as one glyph, so the second of each pair
-        // adds nothing.
-        if (auto const props = codepoint_properties::get(cp);
-            props.grapheme_cluster_break == Grapheme_Cluster_Break::Regional_Indicator)
-        {
-            ++regionalIndicators;
-            if (regionalIndicators % 2 == 0)
-                continue;
-        }
-        else
-            regionalIndicators = 0;
-
-        // A skin tone modifier is absorbed by the emoji it modifies rather than placed beside it.
-        if (cp >= 0x1F3FB && cp <= 0x1F3FF && previousIsEmojiModifierBase)
-            continue;
-
-        if (cp == 0x200D) // ZWJ
-        {
-            // A ZWJ consumes the codepoint that follows it, which is why an emoji ZWJ sequence is
-            // measured by its first segment rather than by its widest member. After a virama the ZWJ
-            // is merely a joining hint, so the consonant behind it must still be seen.
-            if (!previousWasVirama && i + 1 < cluster.size())
-                ++i;
-            continue;
-        }
-
-        if (cp == 0xFE0F && current != 0) // VS16: emoji presentation
-        {
-            current = 2;
-            previousWasVirama = false;
-            continue;
-        }
-
-        if (cp == 0xFE0E && current == 2) // VS15: text presentation
-        {
-            current = 1;
-            previousWasVirama = false;
-            continue;
-        }
-
-        auto const properties = codepoint_properties::get(cp);
-        if (auto const w = static_cast<unsigned>(properties.char_width); w != 0)
-        {
-            if (previousWasVirama)
-                // A consonant joined to the previous one through a virama: the conjunct they form is
-                // wider than one cell, but never wider than two.
-                current = 2;
-            else if (current != 0)
-            {
-                total += current;
-                current = w;
-            }
-            else
-                current = w;
-            previousWasVirama = false;
-            previousIsEmojiModifierBase = properties.is_emoji_modifier_base();
-        }
-        else if (properties.is_virama())
-            previousWasVirama = true;
-        else if (properties.general_category == General_Category::Spacing_Mark && current != 0)
-        {
-            // A spacing mark takes room of its own next to its base, unlike a non-spacing one.
-            current = 2;
-            previousWasVirama = false;
-        }
-        else
-            previousWasVirama = false;
-    }
-
-    return total + current;
+    auto accumulator = grapheme_cluster_width_accumulator {};
+    for (auto const codepoint: cluster)
+        accumulator.push(codepoint);
+    return accumulator.width();
 }
 
 unsigned grapheme_cluster_width(std::string_view utf8Text) noexcept

--- a/src/libunicode/width.h
+++ b/src/libunicode/width.h
@@ -21,22 +21,77 @@ namespace unicode
 /// Returns the number of text columns the given codepoint would need to be displayed.
 unsigned width(char32_t codepoint) noexcept;
 
+/// Measures a single grapheme cluster one codepoint at a time.
+///
+/// This is the one place a cluster's width is decided. grapheme_cluster_width() drives it over a
+/// complete cluster, and scan_text() drives it as it decodes, so the two cannot drift apart on how
+/// wide the same text is -- a disagreement that shows up as a terminal drawing text one column
+/// narrower than it reserved cells for.
+///
+/// Feed a cluster's codepoints in order with push(); read width() at any point for the width of what
+/// has been fed so far; call reset() to begin the next cluster.
+class grapheme_cluster_width_accumulator
+{
+  public:
+    /// Feeds the next codepoint of the current grapheme cluster.
+    void push(char32_t codepoint) noexcept;
+
+    /// Width, in columns, of everything pushed since construction or the last reset().
+    [[nodiscard]] unsigned width() const noexcept;
+
+    /// Begins a new grapheme cluster, discarding all accumulated state.
+    void reset() noexcept { *this = {}; }
+
+  private:
+    // A variation selector or spacing mark re-presents the codepoint most recently *measured*, which
+    // is not always the one just before it: zero-width members are stepped over, and a selector that
+    // has already been applied must not apply a second time. Tracking that codepoint, its width, and
+    // whether it is still open to modification is what keeps this in step with wcwidth.
+    char32_t _lastMeasured = 0;
+    int _lastMeasuredWidth = 0;
+    bool _lastMeasuredIsOpen = false; // false blocks VS15/VS16: nothing to re-present
+
+    // Signed, because VS15 settles its correction against the running total the way wcwidth does.
+    int _total = 0;   // width of the segments already closed off
+    int _current = 0; // width of the segment being accumulated
+
+    bool _previousWasVirama = false;
+    bool _skipNext = false; // a ZWJ consumes the codepoint that follows it
+    unsigned _regionalIndicators = 0;
+};
+
 /// Computes the display width of a single grapheme cluster.
 ///
 /// A cluster is not simply as wide as its base codepoint: later members can widen it.
-/// - VS16 (U+FE0F) requests the emoji presentation, which is two columns.
-/// - VS15 (U+FE0E) requests the text presentation, which is one.
+/// - VS16 (U+FE0F) requests the emoji presentation, which is two columns -- but only for a base an
+///   emoji variation sequence is defined for. `✔️` (U+2714) is two columns; `✓️` (U+2713, which has
+///   no variation sequence) stays one, as does a variation selector after ordinary text.
+/// - VS15 (U+FE0E) requests the text presentation, which is one column, under the same restriction.
+///   It does not narrow a CJK ideograph, a Hangul jamo, or a cluster widened by a spacing mark.
 /// - A spacing mark (General_Category=Mc) takes room of its own beside its base, unlike a
 ///   non-spacing mark, so `का` (ka + AA matra) is two columns while `कं` (ka + anusvara) is one.
 /// - A consonant joined to the previous one through a virama forms a conjunct that is two columns
 ///   wide: `क्न` is two, but a dangling `क्` with nothing behind the virama is one.
+/// - An emoji modifier (skin tone) is absorbed by the emoji before it and adds nothing, whether or
+///   not that emoji is Emoji_Modifier_Base.
 /// - ZWJ (U+200D) does NOT widen. It consumes the codepoint that follows it, so an emoji ZWJ
 ///   sequence is measured by its first segment: U+2764 U+200D U+1F525 (heart on fire, written
 ///   without VS16) is one column. RGI sequences reach two columns through VS16 or a wide base.
 ///
-/// This matches Python wcwidth 0.8's wcswidth(), which terminal applications measure against, and
-/// which was ported here rather than approximated -- an approximation agreed with it on only 99% of
-/// a 3607-grapheme corpus, while this agrees on all of it.
+/// There is no clamp at two columns. A cluster holding several codepoints that each take room is as
+/// wide as their sum, which is what wcwidth reports: two Hangul Choseong jamo form one cluster four
+/// columns wide.
+///
+/// This is a port of Python wcwidth 0.8's wcswidth(), which terminal applications measure against,
+/// rather than an approximation of it -- an earlier approximation agreed with it on only 99% of a
+/// 3607-grapheme corpus. The cluster algorithm agrees with wcswidth() on every cluster tested,
+/// including all of GraphemeBreakTest.txt and every emoji variation sequence.
+///
+/// The underlying per-codepoint width() is deliberately NOT a wcwidth clone, so a cluster whose
+/// codepoints hit one of those differences inherits it: libunicode reports one column where wcwidth
+/// reports zero for unassigned Default_Ignorable codepoints (most of U+E01F0..U+E0FFF and
+/// U+E0080..U+E00FF), and it measures the Hangul filler characters U+3164 and U+FFA0 as rendered
+/// rather than as nothing. Those choices predate this function and are pinned by their own tests.
 ///
 /// @param graphemeCluster a single grapheme cluster (e.g., as returned by grapheme_segmenter).
 /// @return the display column width of the grapheme cluster.

--- a/src/libunicode/width_test.cpp
+++ b/src/libunicode/width_test.cpp
@@ -110,8 +110,13 @@ TEST_CASE("grapheme_cluster_width.VS16_emoji_presentation", "[width]")
 
 TEST_CASE("grapheme_cluster_width.VS15_text_presentation", "[width]")
 {
-    // Grinning face + VS15 → text presentation
-    CHECK(unicode::grapheme_cluster_width(U"\U0001F600\uFE0E"sv) == 1);
+    // VS15 narrows only a base an emoji variation sequence is actually defined for. U+231A WATCH is
+    // one, so its text presentation is a single column.
+    CHECK(unicode::grapheme_cluster_width(U"\u231A\uFE0E"sv) == 1);
+
+    // U+1F600 GRINNING FACE has NO variation sequence -- there is no text presentation of it to
+    // request -- so a trailing VS15 changes nothing. wcwidth 0.8.2 measures this as two columns.
+    CHECK(unicode::grapheme_cluster_width(U"\U0001F600\uFE0E"sv) == 2);
 }
 
 TEST_CASE("grapheme_cluster_width.ZWJ_sequence", "[width]")
@@ -140,10 +145,10 @@ TEST_CASE("grapheme_cluster_width.ZWJ_does_not_widen", "[width]")
     // ZWJ likewise does not widen a non-emoji ligature request: Arabic lam + ZWJ + alef.
     CHECK(unicode::grapheme_cluster_width(U"ل‍ا"sv) == 1);
 
-    // NOTE: a Devanagari conjunct (ka + virama + ZWJ + ssa) is deliberately NOT asserted here. It is
-    // two columns in wcwidth -- not because of the ZWJ, but because a consonant following a virama
-    // promotes its cluster. That rule is not implemented yet, so pinning either answer here would
-    // encode a belief rather than the oracle.
+    // A Devanagari conjunct written with a ZWJ (ka + virama + ZWJ + ssa) is two columns, but the ZWJ
+    // is not what widens it: the consonant following the virama is. See
+    // grapheme_cluster_width.indic_spacing_mark_and_conjunct, which pins that rule directly.
+    CHECK(unicode::grapheme_cluster_width(U"क्‍ष"sv) == 2);
 }
 
 TEST_CASE("grapheme_cluster_width.indic_spacing_mark_and_conjunct", "[width]")
@@ -161,12 +166,140 @@ TEST_CASE("grapheme_cluster_width.indic_spacing_mark_and_conjunct", "[width]")
     CHECK(unicode::grapheme_cluster_width(U"क्नि"sv) == 2);          // ...+ i matra
     CHECK(unicode::grapheme_cluster_width(U"क्‍ष"sv) == 2); // ka + virama + ZWJ + ssa
 
-    // The virama set must be ALL viramas, not Indic_Conjunct_Break=Linker, which covers six scripts.
-    // Each of these is a conjunct whose virama is outside that set.
+    // Conjuncts across the Brahmic scripts, including the Invisible_Stacker ones.
     CHECK(unicode::grapheme_cluster_width(U"ព្រ"sv) == 2);  // Khmer, U+17D2
     CHECK(unicode::grapheme_cluster_width(U"ᬦ᭄ᬤ"sv) == 2); // Javanese, U+A9C0
     CHECK(unicode::grapheme_cluster_width(U"မ္မ"sv) == 2);  // Myanmar, U+1039
     CHECK(unicode::grapheme_cluster_width(U"മ്മ"sv) == 2);  // Malayalam, U+0D4D
+
+    // The virama set is ALL viramas rather than Indic_Conjunct_Break=Linker. Linker is not
+    // script-limited -- it already covers Khmer, Myanmar, Javanese, Chakma and Tai Tham above -- but
+    // it is smaller: 20 codepoints against 41. These four conjuncts are exactly what the larger set
+    // buys, and each would collapse to one column if the implementation keyed off Linker.
+    CHECK(unicode::grapheme_cluster_width(U"ਕ੍ਨ"sv) == 2); // Gurmukhi, U+0A4D
+    CHECK(unicode::grapheme_cluster_width(U"க்ந"sv) == 2); // Tamil, U+0BCD
+    CHECK(unicode::grapheme_cluster_width(U"ಕ್ನ"sv) == 2); // Kannada, U+0CCD
+    CHECK(unicode::grapheme_cluster_width(U"ක්න"sv) == 2); // Sinhala, U+0DCA
+}
+
+TEST_CASE("grapheme_cluster_width.variation_selector_needs_a_variation_base", "[width]")
+{
+    // A variation selector is a presentation request, not a width modifier: it applies only where an
+    // emoji variation sequence is defined. Every expectation here was read off wcwidth 0.8.2.
+
+    // VS16 widens U+2714 HEAVY CHECK MARK, for which a variation sequence exists...
+    CHECK(unicode::grapheme_cluster_width(U"✔️"sv) == 2);
+    // ...but not U+2713 CHECK MARK, for which none does, and not ordinary text.
+    CHECK(unicode::grapheme_cluster_width(U"✓️"sv) == 1);
+    CHECK(unicode::grapheme_cluster_width(U"x️"sv) == 1); // 'x'
+    CHECK(unicode::grapheme_cluster_width(U"•️"sv) == 1); // bullet
+    CHECK(unicode::grapheme_cluster_width(U"—️"sv) == 1); // em dash
+
+    // VS15 must not narrow a wide character that is not an emoji at all.
+    CHECK(unicode::grapheme_cluster_width(U"漢︎"sv) == 2); // CJK ideograph
+    CHECK(unicode::grapheme_cluster_width(U"ᄀ︎"sv) == 2); // HANGUL CHOSEONG KIYEOK
+
+    // Nor may it undo the widening that a spacing mark or a conjunct performed.
+    CHECK(unicode::grapheme_cluster_width(U"का︎"sv) == 2); // ka + AA matra + VS15
+    CHECK(unicode::grapheme_cluster_width(U"क्न︎"sv) == 2); // ka + virama + na + VS15
+}
+
+TEST_CASE("grapheme_cluster_width.variation_selector_after_zwj", "[width]")
+{
+    // A ZWJ consumes the codepoint behind it but leaves the base it swallowed still open to a
+    // variation selector. wcwidth resolves VS16 purely by looking the base up in its narrow-to-wide
+    // table, so the selector still widens even though the ZWJ zeroed the recorded width.
+    // Regression: gating VS16 on that zeroed width made the selector's position change the answer,
+    // so U+2764 U+200D U+1F525 U+FE0F measured 1 while the RGI spelling measured 2.
+    CHECK(unicode::grapheme_cluster_width(U"❤‍\U0001F525️"sv) == 2); // heart ZWJ fire VS16
+    CHECK(unicode::grapheme_cluster_width(U"❤️‍\U0001F525"sv) == 2); // ...RGI spelling
+    CHECK(unicode::grapheme_cluster_width(U"✔‍\U0001F525️"sv) == 2); // U+2714 is a base
+
+    // ...but only where a variation sequence is actually defined: U+2713 has none.
+    CHECK(unicode::grapheme_cluster_width(U"✓‍\U0001F525️"sv) == 1);
+
+    // VS15 is deliberately NOT symmetric with VS16 here. wcwidth's VS15 branch additionally requires
+    // the *recorded* width to be 2, and the ZWJ zeroed it, so the watch is not narrowed.
+    CHECK(unicode::grapheme_cluster_width(U"⌚‍\U0001F525︎"sv) == 2); // watch ZWJ fire VS15
+}
+
+TEST_CASE("grapheme_cluster_width.repeated_vs15_underflows_like_wcwidth", "[width]")
+{
+    // wcwidth's VS15 branch settles its correction against the running total and -- unlike its VS16
+    // branch -- does NOT mark the base as consumed, so a repeated VS15 decrements a second time.
+    // wcswidth("⌚︎︎") is 0 and a third selector takes it to -1.
+    //
+    // This asymmetry looks like an oversight and has been "fixed" once already. It is not: this
+    // library is a port of wcwidth 0.8, degenerate input included. Only the clamp at zero is ours,
+    // because the return type is unsigned.
+    CHECK(unicode::grapheme_cluster_width(U"⌚︎"sv) == 1);
+    CHECK(unicode::grapheme_cluster_width(U"⌚︎︎"sv) == 0);
+    CHECK(unicode::grapheme_cluster_width(U"⌚︎︎︎"sv) == 0);
+
+    // VS16, by contrast, does mark the base consumed, so repeating it is idempotent.
+    CHECK(unicode::grapheme_cluster_width(U"©️"sv) == 2);
+    CHECK(unicode::grapheme_cluster_width(U"©️️"sv) == 2);
+}
+
+TEST_CASE("grapheme_cluster_width.regional_indicator_run_is_contiguous", "[width]")
+{
+    // A flag is a PAIR of regional indicators, and wcwidth decides whether an RI is the second of a
+    // pair by counting the RIs *immediately* before it. Anything else -- a variation selector, a ZWJ
+    // -- ends the run, so the RI that follows opens a new pair and is measured in full.
+    //
+    // Regression: the pair counter was only cleared on the path that measures a codepoint, and the
+    // ZWJ/VS15/VS16 branches return before reaching it. An RI after a selector was then mistaken for
+    // the second half of a pair and contributed nothing.
+    CHECK(unicode::grapheme_cluster_width(U"\U0001F1EA️\U0001F1EA"sv) == 4);
+    CHECK(unicode::grapheme_cluster_width(U"\U0001F1EA︎\U0001F1EA"sv) == 4);
+    CHECK(unicode::grapheme_cluster_width(U"\U0001F1EA️\U0001F1EA️\U0001F1EA"sv) == 6);
+
+    // An unbroken run still pairs up the way a flag must.
+    CHECK(unicode::grapheme_cluster_width(U"\U0001F1E9\U0001F1EA"sv) == 2);
+    CHECK(unicode::grapheme_cluster_width(U"\U0001F1E9\U0001F1EA\U0001F1E9"sv) == 4);
+
+    // A ZWJ ends the run too, but it also swallows the RI behind it, so that one is never measured.
+    // The run length still counts it: wcwidth scans the raw input backwards, not what it processed.
+    CHECK(unicode::grapheme_cluster_width(U"\U0001F1EA‍\U0001F1EA"sv) == 2);
+    CHECK(unicode::grapheme_cluster_width(U"\U0001F1EA‍\U0001F1EA\U0001F1EA"sv) == 2);
+}
+
+TEST_CASE("grapheme_cluster_width.skin_tone_modifier_is_absorbed", "[width]")
+{
+    // A skin tone modifier is drawn into the emoji before it, so it takes no column of its own. That
+    // holds even when the base is not Emoji_Modifier_Base: such sequences are ill-formed but real,
+    // and a terminal that counts the modifier separately corrupts the rest of the line.
+    CHECK(unicode::grapheme_cluster_width(U"❤\U0001F3FB"sv) == 1); // heart + light skin tone
+    CHECK(unicode::grapheme_cluster_width(U"©\U0001F3FB"sv) == 1); // copyright + light skin tone
+    CHECK(unicode::grapheme_cluster_width(U"\U0001F3F3\U0001F3FB‍\U0001F525"sv) == 1);
+
+    // The well-formed case keeps working.
+    CHECK(unicode::grapheme_cluster_width(U"\U0001F926\U0001F3FC"sv) == 2);
+}
+
+TEST_CASE("width.format_characters", "[width]")
+{
+    // General_Category=Cf is zero-width as a rule, but the ones that are Grapheme_Cluster_Break=
+    // Prepend do render, and wcwidth measures them as one column.
+    CHECK(unicode::width(U'؀') == 1);         // ARABIC NUMBER SIGN
+    CHECK(unicode::width(U'۝') == 1);         // ARABIC END OF AYAH
+    CHECK(unicode::width(U'܏') == 1);         // SYRIAC ABBREVIATION MARK
+    CHECK(unicode::width(U'\U000110BD') == 1); // KAITHI NUMBER SIGN
+
+    // SOFT HYPHEN is Cf but not Prepend; a terminal has no line breaking to hide it with and draws
+    // it as a hyphen, so it is carved out explicitly. wcwidth agrees.
+    CHECK(unicode::width(U'­') == 1);
+    CHECK(unicode::grapheme_cluster_width(U"a­b"sv) == 3);
+
+    // The invisible Cf codepoints stay zero-width. These four in particular are NOT
+    // Default_Ignorable, so a rule keyed off that property wrongly gives them a column.
+    CHECK(unicode::width(U'￹') == 0);        // INTERLINEAR ANNOTATION ANCHOR
+    CHECK(unicode::width(U'￺') == 0);        // INTERLINEAR ANNOTATION SEPARATOR
+    CHECK(unicode::width(U'￻') == 0);        // INTERLINEAR ANNOTATION TERMINATOR
+    CHECK(unicode::width(U'\U00013430') == 0); // EGYPTIAN HIEROGLYPH VERTICAL JOINER
+
+    CHECK(unicode::width(U'‍') == 0); // ZWJ
+    CHECK(unicode::width(U'​') == 0); // ZERO WIDTH SPACE
 }
 
 TEST_CASE("grapheme_cluster_width.two_spacing_codepoints_accumulate", "[width]")


### PR DESCRIPTION
The width work in #136 measured a grapheme cluster by accumulating segments, but three of its rules fired on the accumulated width rather than on the Unicode data that governs them, so clusters came out wider or narrower than wcwidth reports. A terminal that reserves cells from these numbers draws the rest of the line in the wrong column.

The concrete symptoms: a variation selector after ordinary text widened it (`✓️` measured two columns, `x️` two), VS15 narrowed any wide character including CJK ideographs and Hangul jamo (`漢︎` measured one), and a skin tone modifier following anything that is not `Emoji_Modifier_Base` opened a segment of its own (`❤🏻` measured three). Separately, `scan_text()` was never taught the new rules at all, so the library's two public width APIs disagreed on Indic, Thai, Lao and Khmer text — the one case where a terminal scans with one and lays out with the other.

Where a finding turned out to describe behaviour wcwidth also produces — clusters wider than two columns, a ZWJ consuming a zero-width codepoint, a leading virama — the behaviour is kept and documented rather than "fixed" away from the oracle.

## Changes

- VS16 and VS15 now consult the emoji variation sequences instead of the accumulated width. wcwidth's `VS16_NARROW_TO_WIDE` and `VS15_WIDE_TO_NARROW` are exactly the variation bases of width one and width two, so a single derived property reproduces both and regenerates from the UCD rather than going stale as a copied table would.
- An emoji modifier is absorbed after any `Extended_Pictographic` or regional indicator, matching wcwidth, not only after `Emoji_Modifier_Base`.
- The rule granting a `General_Category=Cf` codepoint a column is keyed off `Grapheme_Cluster_Break=Prepend` rather than `Default_Ignorable_Code_Point`, which was 19 codepoints too generous and gave a column to the interlinear annotation marks and the Egyptian hieroglyph format controls.
- `scan_text()` and `grapheme_cluster_width()` are driven by one shared accumulator and can no longer answer differently. This also settles a bug that predates the disagreement: a new cluster's width started at `max(previous cluster's width, …)`, so every non-ASCII cluster inherited a floor from the one before it and the error compounded — `中éé` measured six columns instead of four, affecting any Greek, Cyrillic or accented text after a wide character.
- Generated tables are no longer trusted merely because they exist; a generator newer than its output triggers regeneration, and Emscripten builds, which cannot run the generator, say so instead of silently shipping a mismatched table.
- UCD ranges with endpoints outside the Unicode range are rejected at parse time rather than relying on every table loop to bound-check itself.
- Documentation corrected where it overstated or misdescribed behaviour: the claim of exact wcswidth agreement is narrowed to the cluster algorithm (per-codepoint `width()` deliberately differs on unassigned `Default_Ignorable` ranges and the Hangul fillers), the C API's two width modes are described by what they actually do, and the justification for using the full virama set no longer rests on a false claim about `Indic_Conjunct_Break=Linker`, which in UCD 17.0 does cover the scripts it was said to miss.

Verified against Python wcwidth 0.8.2 over a 1,031,936-cluster sweep with no algorithm divergences; the residue traces to the documented per-codepoint differences. Test coverage is added for each corrected rule, including the four conjuncts (Gurmukhi, Tamil, Kannada, Sinhala) that the full virama set actually buys — the four previously standing in for that case were all inside `Linker` and proved nothing.

Follow-up to #136.