### PR TITLE
Fix macros for <experimental/simd> usage

### DIFF
--- a/src/libunicode/convert_simd_impl.h
+++ b/src/libunicode/convert_simd_impl.h
@@ -8,7 +8,7 @@
 #include <cstdint>
 
 // clang-format off
-#if __has_include(<experimental/simd>) && defined(LIBUNICODE_USE_STD_SIMD) && !defined(__APPLE__) && !defined(__FreeBSD__)
+#if __has_include(<experimental/simd>) && defined(LIBUNICODE_USE_STD_SIMD) && !defined(_LIBCPP_VERSION)
     #define USE_STD_SIMD_CONVERT
     #include <experimental/simd>
     namespace convert_stdx = std::experimental;

--- a/src/libunicode/scan_simd_impl.h
+++ b/src/libunicode/scan_simd_impl.h
@@ -6,7 +6,7 @@
 #include <string_view>
 
 // clang-format off
-#if __has_include(<experimental/simd>) && defined(LIBUNICODE_USE_STD_SIMD) && !defined(__APPLE__) && !defined(__FreeBSD__)
+#if __has_include(<experimental/simd>) && defined(LIBUNICODE_USE_STD_SIMD) && !defined(_LIBCPP_VERSION)
     #define USE_STD_SIMD
     #include <experimental/simd>
     namespace stdx = std::experimental;


### PR DESCRIPTION
Closes: https://github.com/contour-terminal/libunicode/issues/138

Both modern macOS and modern FreeBSD use `libc++`, and the intention of existing macros seem to avoid `experimental/simd` is those cases, but that breaks the build with gcc that uses `libstdc++` by default, and needs to use `experimental/simd`.

If you prefer, the change can be minimized to
```
#if __has_include(<experimental/simd>) && defined(LIBUNICODE_USE_STD_SIMD) && !(defined(__APPLE__) && defined(_LIBCPP_VERSION)) && !defined(__FreeBSD__)
```

P. S. I only tested on macOS, I rely on documentation that FreeBSD defines `_LIBCPP_VERSION` (it is a standard macro for `libc++` detection, not platform-specific.