### PR TITLE
Add --version/-V flag to unicode-query

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,13 @@ jobs:
         run: strip ${{ matrix.binary_path }}
 
       - name: "Verify binary"
-        run: ${{ matrix.binary_path }} help
+        env:
+          RELEASE_TAG: ${{ needs.create-release.outputs.tag }}
+        run: |
+          ${{ matrix.binary_path }} help
+          ${{ matrix.binary_path }} --version
+          # tr -d '\r': on Windows the binary writes CRLF line endings.
+          test "$(${{ matrix.binary_path }} --version | head -n1 | tr -d '\r')" = "unicode-query ${RELEASE_TAG#v}"
 
       - name: "Prepare artifact"
         run: |

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,6 +1,10 @@
 if(LIBUNICODE_TOOLS)
     add_executable(unicode-query unicode-query.cpp)
     target_link_libraries(unicode-query unicode)
+    target_compile_definitions(unicode-query PRIVATE
+        LIBUNICODE_VERSION="${PROJECT_VERSION}"
+        LIBUNICODE_UCD_VERSION="${LIBUNICODE_UCD_VERSION}"
+    )
     if(LIBUNICODE_BUILD_STATIC AND UNIX AND NOT APPLE)
         target_link_libraries(unicode-query "-static")
     endif()

--- a/src/tools/unicode-query.cpp
+++ b/src/tools/unicode-query.cpp
@@ -34,6 +34,10 @@
     #include <unistd.h>
 #endif
 
+#if !defined(LIBUNICODE_VERSION) || !defined(LIBUNICODE_UCD_VERSION)
+    #error "LIBUNICODE_VERSION and LIBUNICODE_UCD_VERSION must be defined by the build system."
+#endif
+
 using namespace std;
 
 namespace
@@ -74,8 +78,15 @@ int printUsage(int exitCode)
 {
     cout << "unicode-query [properties] U+XXXX [...]\n"
          << "              gc [-e] [--] \"Text string\"\n"
-         << "              runs [-e] [--] \"Text string\"\n";
+         << "              runs [-e] [--] \"Text string\"\n"
+         << "              --version | -V\n";
     return exitCode;
+}
+
+int printVersion()
+{
+    cout << "unicode-query " LIBUNICODE_VERSION "\n" << "Unicode data: " LIBUNICODE_UCD_VERSION "\n";
+    return EXIT_SUCCESS;
 }
 
 std::string_view seq(std::string_view const& text)
@@ -287,6 +298,9 @@ int main(int argc, char const* argv[])
     int argIndex = 1;
     if (string_view(argv[argIndex]) == "help")
         return printUsage(EXIT_SUCCESS);
+
+    if (auto const arg = string_view(argv[argIndex]); arg == "--version" || arg == "-V")
+        return printVersion();
 
     if (string_view(argv[argIndex]) == "runs")
     {


### PR DESCRIPTION
A downloaded `unicode-query` binary carries no version information and has no way to report one, so there is no way to tell which release it came from. This came up while cutting 0.9.3, where three of the four released binaries turned out to be bit-identical to 0.9.2's — benign, since the tool links none of the code that changed, but only diagnosable by reading the sources.

`unicode-query --version` (and `-V`) now reports the project version alongside the Unicode data version the binary was built against:

```
unicode-query 0.9.3
Unicode data: 17.0.0
```

## Changes

- Both versions reach the tool as compile definitions, following the existing `LIBUNICODE_UCD_VERSION` precedent in `src/libunicode/CMakeLists.txt`. A preprocessor guard makes a build that fails to define them fail loudly rather than silently producing a versionless binary.
- The flag is handled before subcommand dispatch — previously `-V` fell through to codepoint parsing and reported `Failed to parse codepoint -V`.
- The release workflow's binary verification step now asserts that the built binary reports exactly the version being released, so a forgotten version bump fails the build instead of shipping a mislabelled binary. It strips CR before comparing, since the Windows binary writes CRLF.

As a side effect, each release's binaries now embed a distinct version string and will no longer be bit-identical across versions.