### PR TITLE
Add ASan/UBSan/TSan presets and CI coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,31 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+  ignore:
+    - src/libunicode/**/*_test.cpp
+    - src/libunicode/tablegen/**
+    - _deps/*
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,8 +113,11 @@ jobs:
         run: ctest --preset clang-coverage
       - name: "Collect coverage"
         run: |
-          lcov --directory build/clang-coverage --capture --output-file coverage.info
-          lcov --remove coverage.info '/usr/*' '*/_deps/*' '*_test.cpp' --output-file coverage.info
+          chmod +x scripts/llvm-gcov.sh
+          lcov --gcov-tool "$PWD/scripts/llvm-gcov.sh" --ignore-errors inconsistent,gcov,source \
+            --directory build/clang-coverage --capture --output-file coverage.info
+          lcov --ignore-errors inconsistent \
+            --remove coverage.info '/usr/*' '*/_deps/*' '*_test.cpp' --output-file coverage.info
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.info
           fail_ci_if_error: false
   # }}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,33 @@ jobs:
           fail_ci_if_error: false
   # }}}
 
+  # {{{ Valgrind
+  valgrind:
+    name: "Valgrind"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: "ccache-valgrind"
+          max-size: 256M
+      - name: "Update package database"
+        run: sudo apt -q update
+      - name: "install dependencies"
+        run: |
+          ./scripts/install-deps.sh
+          sudo apt install -y valgrind
+      - name: "Generate build files"
+        run: cmake --preset clang-debug
+      - name: "Build"
+        run: cmake --build --preset clang-debug -- -j3
+      - name: "Test under Valgrind"
+        run: |
+          valgrind --error-exitcode=1 --leak-check=full --track-origins=yes \
+            ./build/clang-debug/src/libunicode/unicode_test
+  # }}}
+
   # {{{ Ubuntu ARM64
   ubuntu_arm64:
     name: "Ubuntu ARM64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,67 @@ jobs:
           name: unicode-query-linux-x86_64
           path: build/src/tools/unicode-query
 
+  # {{{ Sanitizers (ASan/UBSan, TSan)
+  sanitize:
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: ['asan', 'tsan']
+    name: "Sanitize (${{ matrix.sanitizer }})"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: "ccache-sanitize-${{ matrix.sanitizer }}"
+          max-size: 256M
+      - name: "Update package database"
+        run: sudo apt -q update
+      - name: "install dependencies"
+        run: ./scripts/install-deps.sh
+      - name: "Generate build files"
+        run: cmake --preset clang-${{ matrix.sanitizer }}
+      - name: "Build"
+        run: cmake --build --preset clang-${{ matrix.sanitizer }} -- -j3
+      - name: "Test"
+        run: ctest --preset clang-${{ matrix.sanitizer }}
+  # }}}
+
+  # {{{ Code coverage
+  coverage:
+    name: "Code coverage"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: "ccache-coverage"
+          max-size: 256M
+      - name: "Update package database"
+        run: sudo apt -q update
+      - name: "install dependencies"
+        run: |
+          ./scripts/install-deps.sh
+          sudo apt install -y lcov
+      - name: "Generate build files"
+        run: cmake --preset clang-coverage
+      - name: "Build"
+        run: cmake --build --preset clang-coverage -- -j3
+      - name: "Test"
+        run: ctest --preset clang-coverage
+      - name: "Collect coverage"
+        run: |
+          lcov --directory build/clang-coverage --capture --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' '*/_deps/*' '*_test.cpp' --output-file coverage.info
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.info
+          fail_ci_if_error: false
+  # }}}
+
   # {{{ Ubuntu ARM64
   ubuntu_arm64:
     name: "Ubuntu ARM64"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ option(LIBUNICODE_BENCHMARK "libunicode: Enables building of benchmark for libun
 option(LIBUNICODE_TOOLS "libunicode: Builds CLI tools [default: ${MASTER_PROJECT}]" ${MASTER_PROJECT})
 option(LIBUNICODE_BUILD_STATIC "libunicode: provide static library instead of dynamic [default: ${LIBUNICODE_BUILD_STATIC_DEFAULT}]" ${LIBUNICODE_BUILD_STATIC_DEFAULT})
 option(LIBUNICODE_TABLEGEN_FASTBUILD "libunicode: Use fast table generation (takes more memory in final tables) [default: OFF]" OFF)
+option(LIBUNICODE_SANITIZE "libunicode: Builds with sanitizer enabled [default: OFF]" "OFF")
 
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" SYSTEM_PROCESSOR_LOWER)
 
@@ -105,6 +106,35 @@ if(LIBUNICODE_COVERAGE AND NOT MSVC)
     message("-- [code coverage] Enabled.")
 else()
     message("-- [code coverage] Disabled.")
+endif()
+
+# ----------------------------------------------------------------------------
+# sanitizers
+
+if(NOT WIN32 AND NOT LIBUNICODE_SANITIZE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(LIBUNICODE_SANITIZE "OFF" CACHE STRING "Choose the sanitizer mode." FORCE)
+    set_property(CACHE LIBUNICODE_SANITIZE PROPERTY STRINGS OFF address thread)
+endif()
+
+if(NOT(LIBUNICODE_SANITIZE STREQUAL "OFF"))
+    # Map the selected sanitizer mode to its -fsanitize set. "address" also enables
+    # UndefinedBehaviorSanitizer (ASan+UBSan compose; ASan+TSan do not). Keep the flags in one
+    # variable so both the compile and the link step receive them -- a sanitizer runtime must be
+    # linked in, not only compiled against.
+    if(LIBUNICODE_SANITIZE STREQUAL "address")
+        set(LIBUNICODE_SANITIZE_FLAGS "-fsanitize=address,undefined -fsanitize-address-use-after-scope")
+    elseif(LIBUNICODE_SANITIZE STREQUAL "thread")
+        set(LIBUNICODE_SANITIZE_FLAGS "-fsanitize=thread")
+    else()
+        set(LIBUNICODE_SANITIZE_FLAGS "-fsanitize=${LIBUNICODE_SANITIZE}")
+    endif()
+    message(STATUS "Enabling ${LIBUNICODE_SANITIZE} sanitizer (flags: ${LIBUNICODE_SANITIZE_FLAGS}).")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer ${LIBUNICODE_SANITIZE_FLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer ${LIBUNICODE_SANITIZE_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LIBUNICODE_SANITIZE_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LIBUNICODE_SANITIZE_FLAGS}")
+else()
+    message(STATUS "No sanitizer enabled.")
 endif()
 
 # ----------------------------------------------------------------------------

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,7 +68,8 @@
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
-                "LIBUNICODE_COVERAGE": "ON"
+                "LIBUNICODE_COVERAGE": "ON",
+                "LIBUNICODE_BUILD_STATIC": "ON"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,6 +72,28 @@
             }
         },
         {
+            "name": "clang-asan",
+            "inherits": "unix-base",
+            "displayName": "Clang Debug + ASan/UBSan",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "LIBUNICODE_SANITIZE": "address"
+            }
+        },
+        {
+            "name": "clang-tsan",
+            "inherits": "unix-base",
+            "displayName": "Clang Debug + TSan",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "LIBUNICODE_SANITIZE": "thread"
+            }
+        },
+        {
             "name": "gcc-debug",
             "inherits": "unix-base",
             "displayName": "GCC Debug",
@@ -159,6 +181,8 @@
         { "name": "clang-release", "configurePreset": "clang-release" },
         { "name": "clang-release-native", "configurePreset": "clang-release-native" },
         { "name": "clang-coverage", "configurePreset": "clang-coverage" },
+        { "name": "clang-asan", "configurePreset": "clang-asan" },
+        { "name": "clang-tsan", "configurePreset": "clang-tsan" },
         { "name": "gcc-debug", "configurePreset": "gcc-debug" },
         { "name": "gcc-release", "configurePreset": "gcc-release" },
         { "name": "gcc-release-native", "configurePreset": "gcc-release-native" },
@@ -172,6 +196,8 @@
         { "name": "clang-release", "configurePreset": "clang-release", "output": { "outputOnFailure": true }, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
         { "name": "clang-release-native", "configurePreset": "clang-release-native", "output": { "outputOnFailure": true }, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
         { "name": "clang-coverage", "configurePreset": "clang-coverage", "output": { "outputOnFailure": true }, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "clang-asan", "configurePreset": "clang-asan", "output": { "outputOnFailure": true }, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
+        { "name": "clang-tsan", "configurePreset": "clang-tsan", "output": { "outputOnFailure": true }, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
         { "name": "gcc-debug", "configurePreset": "gcc-debug", "output": { "outputOnFailure": true }, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
         { "name": "gcc-release", "configurePreset": "gcc-release", "output": { "outputOnFailure": true }, "execution": { "noTestsAction": "error", "stopOnFailure": true } },
         { "name": "gcc-release-native", "configurePreset": "gcc-release-native", "output": { "outputOnFailure": true }, "execution": { "noTestsAction": "error", "stopOnFailure": true } },

--- a/scripts/llvm-gcov.sh
+++ b/scripts/llvm-gcov.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# gcov-tool shim for `lcov`/`geninfo` when the coverage build used Clang.
+#
+# lcov probes its configured gcov tool with a bare "--version" and expects
+# real gcov's semantics (a one-line version banner containing "LLVM" for the
+# Clang case, which geninfo already knows how to map to a gcov version).
+# LLVM's own `gcov` emulation mode does not implement --version as a
+# standalone query -- it tries to treat it as a source-file argument
+# instead -- so intercept that probe here and answer it directly; every
+# other invocation is passed through to `llvm-cov gcov` unchanged.
+set -eu
+
+# Resolve the llvm-cov that matches the compiler actually used, rather than
+# guessing an unversioned "llvm-cov" that may not exist (Ubuntu ships only
+# versioned binaries, e.g. llvm-cov-18). Override with $LLVM_COV if needed.
+CXX="${CXX:-clang++}"
+LLVM_COV="${LLVM_COV:-$("$CXX" --print-prog-name=llvm-cov)}"
+
+if [ "${1:-}" = "--version" ]; then
+    exec "$LLVM_COV" --version
+fi
+exec "$LLVM_COV" gcov "$@"


### PR DESCRIPTION
Adopts the sanitizer preset conventions used in contour so regressions in memory safety, undefined behavior, and data races get caught in CI instead of relying on ad-hoc local runs, and adds automated coverage reporting.

## Changes

- Add a `LIBUNICODE_SANITIZE` CMake option (`address` | `thread`), mirroring contour's `CONTOUR_SANITIZE`.
- Add `clang-asan` (ASan+UBSan) and `clang-tsan` (TSan) presets to `CMakePresets.json`, alongside the existing `clang-coverage` preset.
- Add a CI `sanitize` matrix job running the ASan/UBSan and TSan presets.
- Add a CI `coverage` job building with `clang-coverage`, collecting via `lcov`, and uploading to Codecov.
- Add `.codecov.yml` to configure the coverage report.