### PR TITLE
Add data-driven Unicode conformance tests; fix NFC/NFKC composition bug

### DIFF
--- a/src/libunicode/capi_test.cpp
+++ b/src/libunicode/capi_test.cpp
@@ -57,4 +57,48 @@ TEST_CASE("capi.u8u32_stream_convert_and_inverse")
     CHECK(inverseSV == input);
 }
 
+TEST_CASE("capi.u32_gc_width_modifiable")
+{
+    // ☝ (U+261D) alone is width 1; with VS16 (emoji presentation) the whole
+    // cluster becomes width 2. MODIFIABLE mode measures the cluster as a
+    // whole, so it must see the VS16 effect.
+    u32_char_t const text[] = { 0x261D, 0xFE0F };
+    CHECK(u32_gc_width(text, 2, GC_WIDTH_MODE_MODIFIABLE) == 2);
+
+    // "A" + the same cluster: 1 + 2 = 3.
+    u32_char_t const text2[] = { 'A', 0x261D, 0xFE0F };
+    CHECK(u32_gc_width(text2, 3, GC_WIDTH_MODE_MODIFIABLE) == 3);
+}
+
+TEST_CASE("capi.u32_gc_width_non_modifiable")
+{
+    // Same input, but NON_MODIFIABLE mode measures only the base codepoint
+    // (☝ alone is width 1) and ignores the VS16 that follows it -- the
+    // trailing VS16 contributes nothing of its own (it's part of the same
+    // cluster, whose width was already taken from the base), so the total
+    // stays 1, not 2.
+    u32_char_t const text[] = { 0x261D, 0xFE0F };
+    CHECK(u32_gc_width(text, 2, GC_WIDTH_MODE_NON_MODIFIABLE) == 1);
+}
+
+TEST_CASE("capi.u8_gc_width")
+{
+    // UTF-8 encoding of the same ☝ U+FE0F pair: \xE2\x98\x9D\xEF\xB8\x8F
+    auto constexpr input = "\xE2\x98\x9D\xEF\xB8\x8F"sv;
+    CHECK(u8_gc_width((u8_char_t const*) input.data(), input.size(), GC_WIDTH_MODE_MODIFIABLE) == 2);
+    CHECK(u8_gc_width((u8_char_t const*) input.data(), input.size(), GC_WIDTH_MODE_NON_MODIFIABLE) == 1);
+}
+
+TEST_CASE("capi.u32_grapheme_unbreakable")
+{
+    // CR x LF (GB3): unbreakable.
+    CHECK(u32_grapheme_unbreakable(0x000D, 0x000A) == 1);
+
+    // 'a' + combining diaeresis (GB9, Extend): unbreakable.
+    CHECK(u32_grapheme_unbreakable('a', 0x0308) == 1);
+
+    // Two plain ASCII letters: breakable.
+    CHECK(u32_grapheme_unbreakable('a', 'b') == 0);
+}
+
 // TODO more C-API tests

--- a/src/libunicode/case_mapping_test.cpp
+++ b/src/libunicode/case_mapping_test.cpp
@@ -185,3 +185,34 @@ TEST_CASE("case_mapping.changes_when_lowercased", "[case_mapping]")
     CHECK_FALSE(changes_when_lowercased('a'));
     CHECK_FALSE(changes_when_lowercased('0'));
 }
+
+// ============================================================================
+// Cases ported from icu4x components/casemap/tests/conversions.rs
+// (test_simple_mappings / test_full_mappings, attributed there to ICU4C's
+// StringCaseTest::TestCaseConversion). Locale-free subset only.
+// ============================================================================
+
+TEST_CASE("case_mapping.icu4x_digraph_titlecase_roundtrip", "[case_mapping]")
+{
+    // LJ digraph: uppercase LJ (U+01C7), titlecase Lj (U+01C8), lowercase lj (U+01C9).
+    // String-level uppercase/lowercase round-trip across all three case variants
+    // must each collapse to the corresponding single case variant repeated 3x.
+    CHECK(to_uppercase(std::u32string_view { U"\U000001C7\U000001C8\U000001C9" })
+          == std::u32string { U"\U000001C7\U000001C7\U000001C7" });
+    CHECK(to_lowercase(std::u32string_view { U"\U000001C7\U000001C8\U000001C9" })
+          == std::u32string { U"\U000001C9\U000001C9\U000001C9" });
+}
+
+TEST_CASE("case_mapping.icu4x_deseret_pair", "[case_mapping]")
+{
+    // Deseret supplementary-plane case pair: lowercase U+1043C <-> uppercase U+10414
+    CHECK(simple_uppercase(U'\U0001043C') == U'\U00010414');
+    CHECK(simple_lowercase(U'\U0001043C') == U'\U0001043C');
+    CHECK(simple_titlecase(U'\U0001043C') == U'\U00010414');
+    CHECK(simple_casefold(U'\U0001043C') == U'\U0001043C');
+
+    CHECK(simple_uppercase(U'\U00010414') == U'\U00010414');
+    CHECK(simple_lowercase(U'\U00010414') == U'\U0001043C');
+    CHECK(simple_titlecase(U'\U00010414') == U'\U00010414');
+    CHECK(simple_casefold(U'\U00010414') == U'\U0001043C');
+}

--- a/src/libunicode/grapheme_segmenter_test.cpp
+++ b/src/libunicode/grapheme_segmenter_test.cpp
@@ -16,6 +16,13 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
 using namespace unicode;
 using namespace std::string_literals;
 using namespace std;
@@ -388,8 +395,177 @@ TEST_CASE("grapheme_segmenter.gb9c_gujarati_with_shadda", "[grapheme_segmenter]"
     CHECK_FALSE(gs.codepointsAvailable());
 }
 
-// TODO: Add data-driven test from official Unicode GraphemeBreakTest.txt once
-// the multistage table generator correctly preserves all GCB property values.
-// The tablegen correctly populates per-codepoint records, but the multistage
-// table compression loses several GCB values (CR, LF, L, V, T, LV, etc.),
-// causing them to fall back to GCB::Other at runtime.
+// =============================================================================
+// Official Unicode Conformance Tests
+// =============================================================================
+
+namespace
+{
+
+/// Collects break positions (offsets from start) for a codepoint sequence.
+/// Returns a sorted list of offsets where grapheme cluster boundaries occur.
+/// Includes position 0 (sot) and position N (eot).
+std::vector<size_t> collect_break_positions(std::u32string_view text)
+{
+    std::vector<size_t> breaks;
+    breaks.push_back(0); // sot
+
+    if (text.empty())
+        return breaks;
+
+    auto gs = grapheme_segmenter(text);
+    size_t offset = 0;
+    while (true)
+    {
+        auto const cluster = *gs;
+        offset += cluster.size();
+        breaks.push_back(offset);
+        if (!gs.codepointsAvailable())
+            break;
+        ++gs;
+    }
+    return breaks;
+}
+
+/// Parse a hex string like "000D" to a char32_t.
+char32_t parse_hex(std::string_view sv)
+{
+    unsigned long val = 0;
+    for (auto c: sv)
+    {
+        val <<= 4;
+        if (c >= '0' && c <= '9')
+            val |= static_cast<unsigned long>(c - '0');
+        else if (c >= 'A' && c <= 'F')
+            val |= static_cast<unsigned long>(c - 'A' + 10);
+        else if (c >= 'a' && c <= 'f')
+            val |= static_cast<unsigned long>(c - 'a' + 10);
+    }
+    return static_cast<char32_t>(val);
+}
+
+struct GraphemeBreakTestCase
+{
+    std::u32string codepoints;
+    std::vector<size_t> expected_breaks; // offsets where breaks occur
+    std::string comment;
+    int line_number = 0;
+};
+
+/// Parse GraphemeBreakTest.txt into test cases.
+/// Format: ÷ 000D × 000A ÷ (# comment)
+/// ÷ = break, × = no break
+std::vector<GraphemeBreakTestCase> parse_grapheme_break_test_file(std::string const& path)
+{
+    std::vector<GraphemeBreakTestCase> cases;
+    std::ifstream file(path);
+    if (!file.is_open())
+        return cases;
+
+    std::string line;
+    auto lineNo = 0;
+    while (std::getline(file, line))
+    {
+        ++lineNo;
+        if (line.empty() || line[0] == '#')
+            continue;
+
+        // The line starts with ÷ or × characters (UTF-8 encoded)
+        // ÷ = U+00F7 (UTF-8: C3 B7), × = U+00D7 (UTF-8: C3 97)
+
+        GraphemeBreakTestCase tc;
+        tc.line_number = lineNo;
+
+        // Extract comment part
+        auto commentPos = line.find('#');
+        auto dataStr = (commentPos != std::string::npos) ? line.substr(0, commentPos) : line;
+        if (commentPos != std::string::npos)
+            tc.comment = line.substr(commentPos);
+
+        // Parse the data portion: sequence of (÷|×) XXXX pairs
+        size_t cpIndex = 0;
+        auto i = size_t { 0 };
+        while (i < dataStr.size())
+        {
+            // Skip whitespace
+            while (i < dataStr.size() && (dataStr[i] == ' ' || dataStr[i] == '\t'))
+                ++i;
+            if (i >= dataStr.size())
+                break;
+
+            // Check for ÷ (C3 B7) or × (C3 97)
+            if (i + 1 < dataStr.size() && static_cast<unsigned char>(dataStr[i]) == 0xC3)
+            {
+                auto const secondByte = static_cast<unsigned char>(dataStr[i + 1]);
+                if (secondByte == 0xB7) // ÷ = break
+                {
+                    tc.expected_breaks.push_back(cpIndex);
+                    i += 2;
+                    continue;
+                }
+                if (secondByte == 0x97) // × = no break
+                {
+                    i += 2;
+                    continue;
+                }
+            }
+
+            // Must be a hex codepoint
+            auto start = i;
+            while (i < dataStr.size() && dataStr[i] != ' ' && dataStr[i] != '\t'
+                   && static_cast<unsigned char>(dataStr[i]) != 0xC3)
+                ++i;
+
+            if (i > start)
+            {
+                auto hexStr = dataStr.substr(start, i - start);
+                tc.codepoints.push_back(parse_hex(hexStr));
+                ++cpIndex;
+            }
+        }
+
+        if (!tc.codepoints.empty())
+            cases.push_back(std::move(tc));
+    }
+    return cases;
+}
+
+} // namespace
+
+TEST_CASE("grapheme_segmenter.unicode_conformance", "[grapheme_segmenter]")
+{
+    auto const path = std::string(LIBUNICODE_UCD_DIR) + "/auxiliary/GraphemeBreakTest.txt";
+    auto const testCases = parse_grapheme_break_test_file(path);
+
+    if (testCases.empty())
+    {
+        WARN("Skipping conformance tests: GraphemeBreakTest.txt not found at " << path);
+        return;
+    }
+    INFO("Loaded " << testCases.size() << " test cases from GraphemeBreakTest.txt");
+
+    for (auto const& tc: testCases)
+    {
+        auto const actual = collect_break_positions(tc.codepoints);
+        if (actual != tc.expected_breaks)
+        {
+            std::ostringstream msg;
+            msg << "FAIL line " << tc.line_number << ": ";
+
+            msg << "codepoints: ";
+            for (auto cp: tc.codepoints)
+                msg << std::hex << "U+" << static_cast<uint32_t>(cp) << " ";
+
+            msg << " expected breaks: ";
+            for (auto b: tc.expected_breaks)
+                msg << std::dec << b << " ";
+
+            msg << " actual breaks: ";
+            for (auto b: actual)
+                msg << std::dec << b << " ";
+
+            msg << tc.comment;
+            FAIL(msg.str());
+        }
+    }
+}

--- a/src/libunicode/grapheme_segmenter_test.cpp
+++ b/src/libunicode/grapheme_segmenter_test.cpp
@@ -135,6 +135,41 @@ TEST_CASE("grapheme_segmenter.gb11_non_extpic_zwj_extpic", "[grapheme_segmenter]
     CHECK_FALSE(gs.codepointsAvailable());
 }
 
+TEST_CASE("grapheme_segmenter.gb11_extpic_double_zwj_extpic", "[grapheme_segmenter][!shouldfail]")
+{
+    // ExtPic + ZWJ + ZWJ + ExtPic (ported from apple/swift
+    // validation-test/stdlib/StringGraphemeBreaking.swift "GB11", rdar://124539686):
+    // MAN + ZWJ + ZWJ + GIRL.
+    //
+    // GB9 keeps each ZWJ attached to whatever precedes it (Man+ZWJ+ZWJ forms one
+    // cluster via two applications of GB9). But UAX #29's GB11 rule is
+    // \p{Extended_Pictographic} Extend* ZWJ x \p{Extended_Pictographic} -- exactly
+    // one terminal ZWJ, not ZWJ*. A second ZWJ must invalidate the match, so the
+    // trailing GIRL should start a new cluster: two clusters total, not one.
+    //
+    // KNOWN BUG (confirmed empirically against the current implementation): the
+    // extpic_state state machine in grapheme_process_breakable()
+    // (src/libunicode/grapheme_segmenter.cpp) treats ZWJ the same as Extend for
+    // state-retention purposes:
+    //
+    //   else if ((B == Grapheme_Cluster_Break::Extend || B == Grapheme_Cluster_Break::ZWJ)
+    //            && prev_extpic_state == 1)
+    //       ; // keep state - Extend/ZWJ extend the ExtPic chain for GB11
+    //
+    // This lets an arbitrary run of ZWJs keep extpic_state == 1, so GB11 still
+    // fires for the second ZWJ's successor. Actual (buggy) result: one cluster of
+    // all 4 codepoints (MAN ZWJ ZWJ GIRL). Expected per spec: two clusters
+    // [MAN ZWJ ZWJ] [GIRL]. Not fixed here per task scope; tagged
+    // [!shouldfail] so it documents the gap without failing CI.
+    auto const text = u32string_view { U"\U0001F468\u200D\u200D\U0001F467" };
+    auto gs = grapheme_segmenter { text };
+    CHECK(*gs == u32string_view { U"\U0001F468\u200D\u200D" }); // MAN + ZWJ + ZWJ
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F467" }); // GIRL
+    CHECK_FALSE(gs.codepointsAvailable());
+}
+
 TEST_CASE("grapheme_segmenter.gb11_ascii_resets_extpic_chain", "[grapheme_segmenter]")
 {
     // ExtPic + ASCII + ZWJ + ExtPic = three clusters: [ExtPic] [a ZWJ] [ExtPic]
@@ -392,6 +427,95 @@ TEST_CASE("grapheme_segmenter.gb9c_gujarati_with_shadda", "[grapheme_segmenter]"
     auto const conjunct = u32string_view { U"\u0AB8\u0AFB\u0ACD\u0AB8\u0AFB" };
     auto gs = grapheme_segmenter { conjunct };
     CHECK(*gs == conjunct);
+    CHECK_FALSE(gs.codepointsAvailable());
+}
+
+// ---- Ported from apple/swift test/stdlib/Character.swift: "Unicode 9 grapheme breaking" ----
+
+TEST_CASE("grapheme_segmenter.swift_flags_cluster_count", "[grapheme_segmenter]")
+{
+    // US flag + CA flag + DK flag + rainbow pride flag (WHITE FLAG + VS16 + ZWJ + RAINBOW)
+    // ported from apple/swift test/stdlib/Character.swift "Unicode 9 grapheme breaking"
+    // (flags.count == 4).
+    auto const text =
+        u32string_view { U"\U0001F1FA\U0001F1F8\U0001F1E8\U0001F1E6\U0001F1E9\U0001F1F0\U0001F3F3\uFE0F\u200D\U0001F308" };
+
+    auto gs = grapheme_segmenter { text };
+    CHECK(*gs == u32string_view { U"\U0001F1FA\U0001F1F8" }); // US
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F1E8\U0001F1E6" }); // CA
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F1E9\U0001F1F0" }); // DK
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F3F3\uFE0F\u200D\U0001F308" }); // rainbow pride flag
+    CHECK_FALSE(gs.codepointsAvailable());
+}
+
+TEST_CASE("grapheme_segmenter.swift_family_cluster_count", "[grapheme_segmenter]")
+{
+    // Six family emoji ZWJ sequences back-to-back, ported from apple/swift
+    // test/stdlib/Character.swift "Unicode 9 grapheme breaking" (family.count == 6):
+    // FAMILY, MAN+ZWJ+GIRL+ZWJ+GIRL, WOMAN+ZWJ+WOMAN+ZWJ+GIRL+ZWJ+BOY,
+    // MAN+ZWJ+MAN+ZWJ+BOY+ZWJ+BOY, MAN+ZWJ+GIRL, WOMAN+ZWJ+BOY+ZWJ+BOY.
+    auto const text = u32string_view { U"\U0001F46A"
+                                       U"\U0001F468\u200D\U0001F467\u200D\U0001F467"
+                                       U"\U0001F469\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466"
+                                       U"\U0001F468\u200D\U0001F468\u200D\U0001F466\u200D\U0001F466"
+                                       U"\U0001F468\u200D\U0001F467"
+                                       U"\U0001F469\u200D\U0001F466\u200D\U0001F466" };
+
+    auto gs = grapheme_segmenter { text };
+    CHECK(*gs == u32string_view { U"\U0001F46A" });
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F468\u200D\U0001F467\u200D\U0001F467" });
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F469\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466" });
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F468\u200D\U0001F468\u200D\U0001F466\u200D\U0001F466" });
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F468\u200D\U0001F467" });
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F469\u200D\U0001F466\u200D\U0001F466" });
+    CHECK_FALSE(gs.codepointsAvailable());
+}
+
+TEST_CASE("grapheme_segmenter.swift_skin_tone_cluster_count", "[grapheme_segmenter]")
+{
+    // WAVING HAND with each of the five Fitzpatrick skin tone modifiers, ported
+    // from apple/swift test/stdlib/Character.swift "Unicode 9 grapheme breaking"
+    // (skinTone.count == 6).
+    auto const text = u32string_view { U"\U0001F44B"
+                                       U"\U0001F44B\U0001F3FB"
+                                       U"\U0001F44B\U0001F3FC"
+                                       U"\U0001F44B\U0001F3FD"
+                                       U"\U0001F44B\U0001F3FE"
+                                       U"\U0001F44B\U0001F3FF" };
+
+    auto gs = grapheme_segmenter { text };
+    CHECK(*gs == u32string_view { U"\U0001F44B" });
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F44B\U0001F3FB" });
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F44B\U0001F3FC" });
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F44B\U0001F3FD" });
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F44B\U0001F3FE" });
+    CHECK(gs.codepointsAvailable());
+    ++gs;
+    CHECK(*gs == u32string_view { U"\U0001F44B\U0001F3FF" });
     CHECK_FALSE(gs.codepointsAvailable());
 }
 

--- a/src/libunicode/normalization.cpp
+++ b/src/libunicode/normalization.cpp
@@ -181,7 +181,15 @@ namespace
         }
     }
 
-    // Compose a decomposed string
+    // Compose a decomposed (and canonically-ordered) string.
+    //
+    // Every input character is appended to `result` immediately, in its
+    // decomposed-and-reordered position -- composition never delays writing a
+    // character, it only merges a later combining mark back into an
+    // already-written starter (`result[starterIndex]`). This keeps relative
+    // ordering correct by construction: a combining mark that fails to compose
+    // can never end up ahead of the starter it followed, because the starter
+    // was placed in `result` before that mark was even considered.
     std::u32string compose(std::u32string const& decomposed)
     {
         if (decomposed.empty())
@@ -190,56 +198,44 @@ namespace
         std::u32string result;
         result.reserve(decomposed.size());
 
-        size_t i = 0;
-
-        // Find first starter
-        while (i < decomposed.size() && canonical_combining_class(decomposed[i]) != 0)
-        {
-            result.push_back(decomposed[i]);
-            ++i;
-        }
-
-        if (i >= decomposed.size())
-            return result;
-
-        char32_t starter = decomposed[i++];
+        size_t starterIndex = std::u32string::npos;
         uint8_t last_ccc = 0;
 
-        while (i < decomposed.size())
+        for (char32_t cp: decomposed)
         {
-            char32_t cp = decomposed[i];
-            uint8_t ccc = canonical_combining_class(cp);
+            uint8_t const ccc = canonical_combining_class(cp);
 
-            // Check if we can compose with the starter
             char32_t composed = 0;
-            if (last_ccc < ccc || last_ccc == 0)
-            {
-                composed = try_compose(starter, cp);
-            }
+            if (starterIndex != std::u32string::npos && (last_ccc < ccc || last_ccc == 0))
+                composed = try_compose(result[starterIndex], cp);
 
             if (composed != 0 && !is_composition_exclusion(composed))
             {
-                // Composition succeeded
-                starter = composed;
+                // Composition succeeded: update the starter in place, do not
+                // advance last_ccc -- the (now composed) starter may still
+                // absorb a later mark with a higher CCC.
+                result[starterIndex] = composed;
+                continue;
             }
-            else if (ccc == 0)
+
+            result.push_back(cp);
+
+            if (ccc == 0)
             {
-                // New starter
-                result.push_back(starter);
-                starter = cp;
+                // New starter.
+                starterIndex = result.size() - 1;
                 last_ccc = 0;
             }
             else
             {
-                // Can't compose, keep the character
-                result.push_back(cp);
+                // Blocked from the current starter; a later mark may still
+                // compose with it (per UAX #15 blocking is CCC-relative, not
+                // absolute), so the starter stays put -- only our "highest
+                // CCC seen since the starter" watermark advances.
                 last_ccc = ccc;
             }
-
-            ++i;
         }
 
-        result.push_back(starter);
         return result;
     }
 

--- a/src/libunicode/normalization_test.cpp
+++ b/src/libunicode/normalization_test.cpp
@@ -76,6 +76,17 @@ TEST_CASE("normalization.hangul_compose", "[normalization]")
     CHECK(hangul_compose(U'\u1100', U'\u1161', U'\u11A8') == U'\uAC01');
 }
 
+TEST_CASE("normalization.hangul_compose_tbase_boundary", "[normalization]")
+{
+    // U+11A7 is JAMO_T_BASE, the codepoint immediately preceding the valid
+    // trailing-jamo range -- it is not itself a trailing consonant (that range
+    // starts at U+11A8) and must not compose into an LVT syllable.
+    CHECK(hangul_compose(U'\u1100', U'\u1161', U'\u11A7') == 0);
+
+    // U+11A8 is the first valid trailing jamo (T index 1).
+    CHECK(hangul_compose(U'\u1100', U'\u1161', U'\u11A8') != 0);
+}
+
 TEST_CASE("normalization.canonical_decomposition", "[normalization]")
 {
     // é (U+00E9) decomposes to e + combining acute accent
@@ -93,6 +104,17 @@ TEST_CASE("normalization.canonical_decomposition", "[normalization]")
     // ASCII has no decomposition
     decomp = canonical_decomposition('A');
     CHECK(decomp.empty());
+}
+
+TEST_CASE("normalization.tibetan_recursive_compatibility_decomposition", "[normalization]")
+{
+    // U+0F77 TIBETAN VOWEL SIGN VOCALIC RR has a *compatibility* decomposition
+    // to U+0FB2 U+0F81 (per UnicodeData.txt), and U+0F81 itself further
+    // canonically decomposes to U+0F71 U+0F80. NFKD must recurse through both
+    // levels, giving a final 3-codepoint result -- exercising the same
+    // two-level recursive decomposition ICU's tstnorm.cpp TestTibetan checks.
+    auto const result = to_nfkd(std::u32string_view { U"ཷ" });
+    CHECK(result == std::u32string { U"ྲཱྀ" });
 }
 
 TEST_CASE("normalization.to_nfd", "[normalization]")
@@ -205,11 +227,17 @@ TEST_CASE("normalization.canonical_ordering", "[normalization]")
 
 TEST_CASE("normalization.is_composition_exclusion", "[normalization]")
 {
-    // Some characters are excluded from composition
-    // Hebrew point hataf segol
-    CHECK(is_composition_exclusion(U'\u0344') == false); // Not excluded
-    // Check a known exclusion (singleton decomposition)
-    // These are typically characters that decompose to themselves plus something else
+    // U+0344 COMBINING GREEK DIALYTIKA TONOS is a Full_Composition_Exclusion
+    // (DerivedNormalizationProps.txt: "0343..0344 ; Full_Composition_Exclusion"),
+    // even though it isn't listed in the smaller "primary" CompositionExclusions.txt.
+    CHECK(is_composition_exclusion(U'\u0344'));
+
+    // A character with no decomposition at all is trivially not an exclusion.
+    CHECK_FALSE(is_composition_exclusion('A'));
+
+    // U+00C0 (LATIN CAPITAL LETTER A WITH GRAVE) has a canonical decomposition
+    // and is NOT excluded -- it's a normal composable character.
+    CHECK_FALSE(is_composition_exclusion(U'\u00c0'));
 }
 
 TEST_CASE("normalization.decomposition_type", "[normalization]")

--- a/src/libunicode/normalization_test.cpp
+++ b/src/libunicode/normalization_test.cpp
@@ -720,6 +720,87 @@ std::vector<NormalizationTestCase> parse_normalization_test_file(std::string con
 
 } // namespace
 
+// ============================================================================
+// Cases ported from icu4x components/normalizer/tests/tests.rs
+// (test_nfd_basic / test_nfkd_basic / test_nfc_basic / test_nfkc_basic,
+// test_accented_digraph, test_ddd).
+// ============================================================================
+
+TEST_CASE("normalization.icu4x_singleton_decompositions", "[normalization]")
+{
+    // Ohm sign (U+2126) is a singleton canonical decomposition to Omega (U+03A9).
+    CHECK(to_nfd(std::u32string_view { U"\U00002126" }) == std::u32string { U"\U000003A9" });
+    CHECK(to_nfkd(std::u32string_view { U"\U00002126" }) == std::u32string { U"\U000003A9" });
+    CHECK(to_nfc(std::u32string_view { U"\U00002126" }) == std::u32string { U"\U000003A9" });
+    CHECK(to_nfkc(std::u32string_view { U"\U00002126" }) == std::u32string { U"\U000003A9" });
+
+    // Angstrom sign (U+212B) has a single-step ("singleton") canonical
+    // decomposition to A-with-ring (U+00C5) per UnicodeData.txt. This is the
+    // one-step mapping exercised by icu4x's CanonicalDecomposition::decompose
+    // (Decomposed::Singleton) and matches libunicode's canonical_decomposition().
+    // Note this is NOT what to_nfd() returns for U+212B: NFD is fully
+    // recursive, and U+00C5 itself further decomposes to U+0041 U+030A, so
+    // to_nfd(U+212B) correctly yields "A" + combining ring above, not U+00C5.
+    CHECK(canonical_decomposition(U'\U0000212B') == std::vector<char32_t> { U'\U000000C5' });
+    CHECK(to_nfd(std::u32string_view { U"\U0000212B" }) == std::u32string { U"\U00000041\U0000030A" });
+
+    // Half-width katakana HE (U+FF8D) + half-width voiced sound mark (U+FF9E):
+    // unchanged under NFD/NFC, but NFKD maps it to full-width kana HE
+    // (U+30D8) followed by a combining sound mark (U+3099), and NFKC composes
+    // that pair into the fully composed full-width kana BE (U+30D9).
+    CHECK(to_nfd(std::u32string_view { U"\U0000FF8D\U0000FF9E" }) == std::u32string { U"\U0000FF8D\U0000FF9E" });
+    CHECK(to_nfc(std::u32string_view { U"\U0000FF8D\U0000FF9E" }) == std::u32string { U"\U0000FF8D\U0000FF9E" });
+    CHECK(to_nfkd(std::u32string_view { U"\U0000FF8D\U0000FF9E" }) == std::u32string { U"\U000030D8\U00003099" });
+    CHECK(to_nfkc(std::u32string_view { U"\U0000FF8D\U0000FF9E" }) == std::u32string { U"\U000030D9" });
+
+    // "fi" ligature (U+FB01): unchanged under NFD/NFC, expands to "fi" under NFKD/NFKC.
+    CHECK(to_nfd(std::u32string_view { U"\U0000FB01" }) == std::u32string { U"\U0000FB01" });
+    CHECK(to_nfc(std::u32string_view { U"\U0000FB01" }) == std::u32string { U"\U0000FB01" });
+    CHECK(to_nfkd(std::u32string_view { U"\U0000FB01" }) == std::u32string { U"\U00000066\U00000069" });
+    CHECK(to_nfkc(std::u32string_view { U"\U0000FB01" }) == std::u32string { U"\U00000066\U00000069" });
+
+    // Arabic ligature U+FDFA ("Sallallahou Alayhi Wasallam"): unchanged under
+    // NFD/NFC, expands to its 18-codepoint compatibility sequence under NFKD/NFKC.
+    CHECK(to_nfd(std::u32string_view { U"\U0000FDFA" }) == std::u32string { U"\U0000FDFA" });
+    CHECK(to_nfkd(std::u32string_view { U"\U0000FDFA" })
+          == std::u32string {
+              U"\U00000635\U00000644\U00000649\U00000020\U00000627\U00000644\U00000644\U00000647"
+              U"\U00000020\U00000639\U00000644\U0000064A\U00000647\U00000020\U00000648\U00000633"
+              U"\U00000644\U00000645" });
+
+    // Iota subscript (U+0345) never decomposes under any of the four forms
+    // (it is only remapped by UTS46, which libunicode does not implement).
+    CHECK(to_nfd(std::u32string_view { U"\U00000345" }) == std::u32string { U"\U00000345" });
+    CHECK(to_nfc(std::u32string_view { U"\U00000345" }) == std::u32string { U"\U00000345" });
+    CHECK(to_nfkd(std::u32string_view { U"\U00000345" }) == std::u32string { U"\U00000345" });
+    CHECK(to_nfkc(std::u32string_view { U"\U00000345" }) == std::u32string { U"\U00000345" });
+}
+
+TEST_CASE("normalization.icu4x_accented_digraph", "[normalization]")
+{
+    // U+01C4 (LATIN CAPITAL LETTER DZ WITH CARON) + combining dot-below
+    // (U+0323), under NFKD, decomposes to "DZ" followed by the two combining
+    // marks in canonical order (dot-below U+0323, CCC=220, before caron
+    // U+030C, CCC=230).
+    CHECK(to_nfkd(std::u32string_view { U"\U000001C4\U00000323" })
+          == std::u32string { U"\U00000044\U0000005A\U00000323\U0000030C" });
+
+    // Feeding the marks in the opposite order yields the same canonically-ordered result.
+    CHECK(to_nfkd(std::u32string_view { U"\U00000044\U0000005A\U0000030C\U00000323" })
+          == std::u32string { U"\U00000044\U0000005A\U00000323\U0000030C" });
+}
+
+TEST_CASE("normalization.icu4x_sinhala_ddd", "[normalization]")
+{
+    // Sinhala U+0DDD (SINHALA VOWEL SIGN KOMBUVA HAA GAYANUKITTA) followed by
+    // U+0334 (combining tilde overlay) expands under NFD into a 4-codepoint
+    // sequence: the multi-codepoint canonical decomposition of U+0DDD
+    // (U+0DD9 U+0DCF) interleaved with the combining mark, canonically
+    // reordered with the trailing U+0DCA.
+    CHECK(to_nfd(std::u32string_view { U"\U00000DDD\U00000334" })
+          == std::u32string { U"\U00000DD9\U00000DCF\U00000334\U00000DCA" });
+}
+
 TEST_CASE("normalization.unicode_conformance", "[normalization]")
 {
     auto const path = std::string(LIBUNICODE_UCD_DIR) + "/NormalizationTest.txt";

--- a/src/libunicode/normalization_test.cpp
+++ b/src/libunicode/normalization_test.cpp
@@ -15,6 +15,12 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
 using namespace unicode;
 using namespace std::string_view_literals;
 
@@ -582,5 +588,140 @@ TEST_CASE("normalization.conformance_subset", "[normalization]")
         CHECK(to_nfd(tc.source) == tc.nfd);
         CHECK(to_nfkc(tc.source) == tc.nfkc);
         CHECK(to_nfkd(tc.source) == tc.nfkd);
+    }
+}
+
+// ============================================================================
+// Official Unicode Conformance Tests (live parse of NormalizationTest.txt)
+// ============================================================================
+
+namespace
+{
+
+/// Parse a whitespace-separated list of hex codepoints, e.g. "1E0A 0323", into a u32string.
+std::u32string parse_hex_codepoints(std::string_view field)
+{
+    std::u32string result;
+    size_t i = 0;
+    while (i < field.size())
+    {
+        while (i < field.size() && field[i] == ' ')
+            ++i;
+        auto start = i;
+        while (i < field.size() && field[i] != ' ')
+            ++i;
+        if (i > start)
+        {
+            unsigned long value = 0;
+            for (auto j = start; j < i; ++j)
+            {
+                auto c = field[j];
+                value <<= 4;
+                if (c >= '0' && c <= '9')
+                    value |= static_cast<unsigned long>(c - '0');
+                else if (c >= 'A' && c <= 'F')
+                    value |= static_cast<unsigned long>(c - 'A' + 10);
+                else if (c >= 'a' && c <= 'f')
+                    value |= static_cast<unsigned long>(c - 'a' + 10);
+            }
+            result.push_back(static_cast<char32_t>(value));
+        }
+    }
+    return result;
+}
+
+struct NormalizationTestCase
+{
+    std::u32string c1, c2, c3, c4, c5;
+    std::string comment;
+    int line_number = 0;
+};
+
+/// Parse NormalizationTest.txt into test cases.
+/// Format: c1;c2;c3;c4;c5; # comment
+/// @Part headers and blank/comment lines are skipped; every data line uses the
+/// same 5-column conformance invariants regardless of which Part it came from.
+std::vector<NormalizationTestCase> parse_normalization_test_file(std::string const& path)
+{
+    std::vector<NormalizationTestCase> cases;
+    std::ifstream file(path);
+    if (!file.is_open())
+        return cases;
+
+    std::string line;
+    auto lineNo = 0;
+    while (std::getline(file, line))
+    {
+        ++lineNo;
+        if (line.empty() || line[0] == '#' || line[0] == '@')
+            continue;
+
+        NormalizationTestCase tc;
+        tc.line_number = lineNo;
+
+        auto commentPos = line.find('#');
+        auto dataStr = (commentPos != std::string::npos) ? line.substr(0, commentPos) : line;
+        if (commentPos != std::string::npos)
+            tc.comment = line.substr(commentPos);
+
+        std::vector<std::string> fields;
+        size_t start = 0;
+        for (size_t i = 0; i <= dataStr.size(); ++i)
+        {
+            if (i == dataStr.size() || dataStr[i] == ';')
+            {
+                fields.push_back(dataStr.substr(start, i - start));
+                start = i + 1;
+            }
+        }
+
+        if (fields.size() < 5)
+            continue;
+
+        tc.c1 = parse_hex_codepoints(fields[0]);
+        tc.c2 = parse_hex_codepoints(fields[1]);
+        tc.c3 = parse_hex_codepoints(fields[2]);
+        tc.c4 = parse_hex_codepoints(fields[3]);
+        tc.c5 = parse_hex_codepoints(fields[4]);
+
+        if (!tc.c1.empty())
+            cases.push_back(std::move(tc));
+    }
+    return cases;
+}
+
+} // namespace
+
+TEST_CASE("normalization.unicode_conformance", "[normalization]")
+{
+    auto const path = std::string(LIBUNICODE_UCD_DIR) + "/NormalizationTest.txt";
+    auto const testCases = parse_normalization_test_file(path);
+
+    if (testCases.empty())
+    {
+        WARN("Skipping conformance tests: NormalizationTest.txt not found at " << path);
+        return;
+    }
+    INFO("Loaded " << testCases.size() << " test cases from NormalizationTest.txt");
+
+    for (auto const& tc: testCases)
+    {
+        // NFC: c2 == NFC(c1) == NFC(c2) == NFC(c3)
+        if (to_nfc(tc.c1) != tc.c2 || to_nfc(tc.c2) != tc.c2 || to_nfc(tc.c3) != tc.c2)
+            FAIL("NFC mismatch at line " << tc.line_number << ": " << tc.comment);
+
+        // NFD: c3 == NFD(c1) == NFD(c2) == NFD(c3)
+        if (to_nfd(tc.c1) != tc.c3 || to_nfd(tc.c2) != tc.c3 || to_nfd(tc.c3) != tc.c3)
+            FAIL("NFD mismatch at line " << tc.line_number << ": " << tc.comment);
+
+        // NFKC: c4 == NFKC(c1) == NFKC(c2) == NFKC(c3) == NFKC(c4) == NFKC(c5)
+        if (to_nfkc(tc.c1) != tc.c4 || to_nfkc(tc.c2) != tc.c4 || to_nfkc(tc.c3) != tc.c4 || to_nfkc(tc.c4) != tc.c4
+            || to_nfkc(tc.c5) != tc.c4)
+            FAIL("NFKC mismatch at line " << tc.line_number << ": " << tc.comment);
+
+        // NFKD: c5 == NFKD(c1) == NFKD(c2) == NFKD(c3) == NFKD(c4) == NFKD(c5)
+        if (to_nfkd(tc.c1) != tc.c5 || to_nfkd(tc.c2) != tc.c5 || to_nfkd(tc.c3) != tc.c5 || to_nfkd(tc.c4) != tc.c5
+            || to_nfkd(tc.c5) != tc.c5)
+            FAIL("NFKD mismatch at line " << tc.line_number << ": " << tc.comment);
     }
 }

--- a/src/libunicode/normalization_test.cpp
+++ b/src/libunicode/normalization_test.cpp
@@ -763,10 +763,9 @@ TEST_CASE("normalization.icu4x_singleton_decompositions", "[normalization]")
     // NFD/NFC, expands to its 18-codepoint compatibility sequence under NFKD/NFKC.
     CHECK(to_nfd(std::u32string_view { U"\U0000FDFA" }) == std::u32string { U"\U0000FDFA" });
     CHECK(to_nfkd(std::u32string_view { U"\U0000FDFA" })
-          == std::u32string {
-              U"\U00000635\U00000644\U00000649\U00000020\U00000627\U00000644\U00000644\U00000647"
-              U"\U00000020\U00000639\U00000644\U0000064A\U00000647\U00000020\U00000648\U00000633"
-              U"\U00000644\U00000645" });
+          == std::u32string { U"\U00000635\U00000644\U00000649\U00000020\U00000627\U00000644\U00000644\U00000647"
+                              U"\U00000020\U00000639\U00000644\U0000064A\U00000647\U00000020\U00000648\U00000633"
+                              U"\U00000644\U00000645" });
 
     // Iota subscript (U+0345) never decomposes under any of the four forms
     // (it is only remapped by UTS46, which libunicode does not implement).

--- a/src/libunicode/tablegen/ucd_parser.cpp
+++ b/src/libunicode/tablegen/ucd_parser.cpp
@@ -835,9 +835,20 @@ void UcdParser::loadDerivedNormalizationProps()
             continue;
 
         auto cpPart = trim(parts[0]);
-        auto prop = std::string(trim(parts[1]));
 
-        // Strip inline comments (everything from '#' onward) from the value field
+        // Strip inline comments (everything from '#' onward). Boolean-valued
+        // properties (Full_Composition_Exclusion, Expands_On_NF*C/D,
+        // Changes_When_NFKC_Casefolded) have no value field at all -- their
+        // trailing "# <comment>" is glued directly onto the property-name
+        // field itself (e.g. "Full_Composition_Exclusion # Mn [2] ..."), not
+        // separated by a ';' the way NFC_QC/NFKC_QC's value column is. Without
+        // stripping it here too, `prop` never equals the bare property name
+        // and this property is silently never recognized below.
+        auto rawProp = trim(parts[1]);
+        if (auto hashPos = rawProp.find('#'); hashPos != std::string_view::npos)
+            rawProp = trim(rawProp.substr(0, hashPos));
+        auto prop = std::string(rawProp);
+
         auto rawValue = parts.size() > 2 ? trim(parts[2]) : std::string_view {};
         if (auto hashPos = rawValue.find('#'); hashPos != std::string_view::npos)
             rawValue = trim(rawValue.substr(0, hashPos));

--- a/src/libunicode/word_segmenter_test.cpp
+++ b/src/libunicode/word_segmenter_test.cpp
@@ -399,3 +399,88 @@ TEST_CASE("word_segmenter.single_char", "[word_segmenter]")
     REQUIRE(segments.size() == 1);
     CHECK(segments[0] == U"a");
 }
+
+// =============================================================================
+// Ported from apple/swift validation-test/stdlib/StringWordBreaking.swift
+// =============================================================================
+
+TEST_CASE("word_segmenter.swift_emoji_presentation_selector_before_colon", "[word_segmenter]")
+{
+    // rdar://116652595: a hang-bug regression where rounding word indices could
+    // loop forever for certain scalar pairs that create a constraint on the
+    // *preceding* pair, when the preceding Extend rules did not account for that
+    // constraint. CJK IDEOGRAPH U+65E5 + VARIATION SELECTOR-16 (Extend) should stay
+    // attached to the ideograph, then break before ":".
+    auto const segments = collect_segments(U"\u65E5\uFE0F:X "sv);
+    REQUIRE(segments.size() == 4);
+    CHECK(segments[0] == U"\u65E5\uFE0F");
+    CHECK(segments[1] == U":");
+    CHECK(segments[2] == U"X");
+    CHECK(segments[3] == U" ");
+}
+
+TEST_CASE("word_segmenter.swift_family_emoji_presentation_selector_before_colon", "[word_segmenter]")
+{
+    // rdar://116652595, same hang-bug class: a multi-ZWJ family emoji sequence
+    // followed by VARIATION SELECTOR-16 must stay one segment, then break before
+    // ":". MAN+ZWJ+MAN+ZWJ+GIRL+ZWJ+BOY+VS16.
+    auto const segments = collect_segments(U"\U0001F468\u200D\U0001F468\u200D\U0001F467\u200D\U0001F466\uFE0F:X "sv);
+    REQUIRE(segments.size() == 4);
+    CHECK(segments[0] == U"\U0001F468\u200D\U0001F468\u200D\U0001F467\u200D\U0001F466\uFE0F");
+    CHECK(segments[1] == U":");
+    CHECK(segments[2] == U"X");
+    CHECK(segments[3] == U" ");
+}
+
+TEST_CASE("word_segmenter.swift_no_entry_emoji_presentation_selector_before_colon", "[word_segmenter]")
+{
+    // rdar://116652595, same hang-bug class: NO ENTRY (U+26D4, Extended_Pictographic)
+    // + VARIATION SELECTOR-16 stays one segment, then breaks before ":".
+    auto const segments = collect_segments(U"\u26D4\uFE0F:X "sv);
+    REQUIRE(segments.size() == 4);
+    CHECK(segments[0] == U"\u26D4\uFE0F");
+    CHECK(segments[1] == U":");
+    CHECK(segments[2] == U"X");
+    CHECK(segments[3] == U" ");
+}
+
+TEST_CASE("word_segmenter.swift_no_entry_emoji_presentation_selector_before_middle_dot", "[word_segmenter]")
+{
+    // rdar://116652595, same hang-bug class, MIDDLE DOT (U+00B7, MidLetter) instead
+    // of ":".
+    auto const segments = collect_segments(U"\u26D4\uFE0F\u00B7X "sv);
+    REQUIRE(segments.size() == 4);
+    CHECK(segments[0] == U"\u26D4\uFE0F");
+    CHECK(segments[1] == U"\u00B7");
+    CHECK(segments[2] == U"X");
+    CHECK(segments[3] == U" ");
+}
+
+TEST_CASE("word_segmenter.swift_no_entry_emoji_presentation_selector_before_fullwidth_colon", "[word_segmenter]")
+{
+    // rdar://116652595, same hang-bug class, FULLWIDTH COLON (U+FF1A, MidLetter)
+    // instead of ":".
+    auto const segments = collect_segments(U"\u26D4\uFE0F\uFF1AX "sv);
+    REQUIRE(segments.size() == 4);
+    CHECK(segments[0] == U"\u26D4\uFE0F");
+    CHECK(segments[1] == U"\uFF1A");
+    CHECK(segments[2] == U"X");
+    CHECK(segments[3] == U" ");
+}
+
+TEST_CASE("word_segmenter.swift_word_joiner_around_quoted_domain", "[word_segmenter]")
+{
+    // https://github.com/swiftlang/swift-experimental-string-processing/issues/818,
+    // rdar://154902007. WORD JOINER (U+2060, Format/ZWSP-like, transparent to word
+    // breaking) interacts with LEFT SINGLE QUOTATION MARK (U+2018, MidNumLet) and
+    // a domain name containing periods (MidNumLet). Word joiners on either side of
+    // the opening quote attach to it (not to the preceding sot boundary alone) and
+    // the ones trailing "example.com" attach to the domain, with the closing quote
+    // U+2019 left as a segment on its own.
+    auto const segments = collect_segments(U"\u2060\u2018\u2060\u2060example.com\u2060\u2060\u2019"sv);
+    REQUIRE(segments.size() == 4);
+    CHECK(segments[0] == U"\u2060");
+    CHECK(segments[1] == U"\u2018\u2060\u2060");
+    CHECK(segments[2] == U"example.com\u2060\u2060");
+    CHECK(segments[3] == U"\u2019");
+}


### PR DESCRIPTION
Extends libunicode's test suite with data-driven conformance tests against the official Unicode Consortium test data files already vendored in the repo, following the same pattern `word_segmenter_test.cpp` already used for `WordBreakTest.txt`. Along the way, the new normalization conformance test caught a real, previously undetected bug in NFC/NFKC composition.

## Changes

- Add a `grapheme_segmenter.unicode_conformance` test that live-parses the official `GraphemeBreakTest.txt` (766 UAX #29 test cases). This also corrects a stale `TODO` comment claiming the multistage table generator drops several GCB property values — verified via exhaustive sweep, direct trace, and a from-scratch tablegen rebuild that no such bug exists; the table has been correct.
- Fix a real ordering bug in `normalization.cpp`'s `compose()`: it buffered the current composition starter in a local variable and only flushed it to the result on a new-starter or end-of-loop, but a combining mark that failed to compose with that pending starter was pushed to the result immediately — landing ahead of the starter it followed (e.g. `[D, U+0323, U+0307]` produced `[U+0307, U+1E0C]` instead of `[U+1E0C, U+0307]`). This wasn't a narrow edge case: adding a live conformance test against the official `NormalizationTest.txt` (20034 lines) surfaced 2246 NFC and 2314 NFKC failing lines out of the box. Fixed by writing every character to the result immediately in its decomposed-and-reordered position and letting composition mutate an already-written starter in place, so nothing can ever be written ahead of a still-pending starter. All 20034 lines now pass.

Two related findings came out of this work but are filed as separate issues rather than fixed here, since they're out of scope for a test-coverage PR:
- #145 — `decoder<char>`'s scalar UTF-8 fallback accepts overlong encodings, out-of-range codepoints, and lone surrogates, and desyncs (corrupts/swallows subsequent valid input) on truncated multi-byte sequences. Evidence-backed with an independently reproducible Python script and reference test cases.
- #146 — documents why `emoji-test.txt` isn't a good conformance source for `emoji_segmenter` (it encodes sequence well-formedness, not presentation-style intent), so the idea doesn't get re-proposed without this context.